### PR TITLE
Update islandora_oaipmh for rest_oai_pmh:alpha-10

### DIFF
--- a/modules/islandora_oaipmh/README.md
+++ b/modules/islandora_oaipmh/README.md
@@ -25,7 +25,7 @@ currently requires updating the RDF mapping to include a Dublin Core predicate
 for that field or any other additional fields. Alternatively, the rest\_oai\_pmh module 
 also supports defining mappings with the
 [metatag module](https://www.drupal.org/project/metatag) or creating a custom
-metadata profile using the Twig templating system.
+OaiMetadataMap plugin.
 
 ## Configuration
 

--- a/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
+++ b/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
@@ -7,3 +7,6 @@ mapping_source: rdf
 repository_name: 'Islandora 8'
 repository_email: admin@example.com
 expiration: '3600'
+metadata_map_plugins:
+  oai_raw: ''
+  oai_dc: dublin_core_rdf

--- a/modules/islandora_oaipmh/config/install/views.view.oai_pmh.yml
+++ b/modules/islandora_oaipmh/config/install/views.view.oai_pmh.yml
@@ -251,4 +251,3 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-

--- a/modules/islandora_oaipmh/islandora_oaipmh.info.yml
+++ b/modules/islandora_oaipmh/islandora_oaipmh.info.yml
@@ -2,7 +2,11 @@ name: 'Islandora OAI-PMH Endpoint'
 type: module
 description: 'Default configuration for an OAI-PMH Endpoint'
 core: 8.x
-package: 'Islandora'
+package: Islandora
 dependencies:
-  - rest_oai_pmh
   - islandora_defaults
+  - node
+  - rest_oai_pmh
+  - taxonomy
+  - user
+  - views


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1360

# What does this Pull Request do?

In [the alpha-10 release of rest_oai_pmh](https://www.drupal.org/project/rest_oai_pmh/releases/8.x-1.0-alpha10) the metadata schema selection was changed to using Plugins instead of theme hooks (don't worry, you can still create custom metadata profiles using twig templating). This PR updates the default settings to use the dublin_core_rdf plugin.

# What's new?

* A few Feature-export clean-up bits
* Added default configuration to use dublin_core_rdf plugin
* Does this change require documentation to be updated? See https://github.com/Islandora/documentation/pull/1345
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? **Clear your cache.**
* Could this change impact execution of existing code? Not for a vanilla repository, but if anyone already customized their rest_oai_pmh (which is unlikely at this point), they should now use the new plugin architecture.

# How should this be tested?

- Update rest_oai_pmh: `composer require drupal/rest_oai_pmh` (should now be at least "1.0.0-alpha10").
- Apply the PR
- Feature import: `drush fim -y islandora_oaipmh`
- Clear cache: `drush cr`
- Visit the OAI PMH settings (`http://localhost:8000/admin/config/services/rest/oai-pmh`) and see the 'oai_dc' metadata mapping is configured to use 'OAI Dublin Core (RDF Mapping)'.
- **Bonus**: if you have repository item content, make sure you've built the OAI-PMH entries (`http://localhost:8000/admin/config/services/rest/oai-pmh/queue`) although re-building is not necessary if you've already done so, and make sure it works (`http://localhost:8000/oai/request?verb=ListRecords&metadataPrefix=oai_dc`).

# Interested parties
@Islandora/8-x-committers, @elizoller & @joecorall.
