### PR TITLE
Replaces 'dc' prefix with 'dcterms'

### DIFF
--- a/config/install/rdf.mapping.media.audio.yml
+++ b/config/install/rdf.mapping.media.audio.yml
@@ -16,7 +16,7 @@ types:
 fieldMappings:
   name:
     properties:
-      - 'dc:title'
+      - 'dcterms:title'
       - 'rdf:label'
   created:
     properties:

--- a/config/install/rdf.mapping.media.file.yml
+++ b/config/install/rdf.mapping.media.file.yml
@@ -16,7 +16,7 @@ types:
 fieldMappings:
   name:
     properties:
-      - 'dc:title'
+      - 'dcterms:title'
       - 'rdf:label'
   created:
     properties:

--- a/config/install/rdf.mapping.media.image.yml
+++ b/config/install/rdf.mapping.media.image.yml
@@ -16,7 +16,7 @@ types:
 fieldMappings:
   name:
     properties:
-      - 'dc:title'
+      - 'dcterms:title'
       - 'rdf:label'
   created:
     properties:

--- a/config/install/rdf.mapping.media.video.yml
+++ b/config/install/rdf.mapping.media.video.yml
@@ -16,7 +16,7 @@ types:
 fieldMappings:
   name:
     properties:
-      - 'dc:title'
+      - 'dcterms:title'
       - 'rdf:label'
   created:
     properties:

--- a/config/install/rdf.mapping.node.islandora_object.yml
+++ b/config/install/rdf.mapping.node.islandora_object.yml
@@ -16,45 +16,45 @@ types:
 fieldMappings:
   field_alternative_title:
     properties:
-      - 'dc:alternative'
+      - 'dcterms:alternative'
   field_edtf_date:
     properties:
-      - 'dc:date'
+      - 'dcterms:date'
     datatype_callback:
       callable: 'Drupal\controlled_access_terms\EDTFConverter::dateIso8601Value'
   field_edtf_date_created:
     properties:
-      - 'dc:created'
+      - 'dcterms:created'
     datatype_callback:
       callable: 'Drupal\controlled_access_terms\EDTFConverter::dateIso8601Value'
   field_edtf_date_issued:
     properties:
-      - 'dc:issued'
+      - 'dcterms:issued'
     datatype_callback:
       callable: 'Drupal\controlled_access_terms\EDTFConverter::dateIso8601Value'
   field_description:
     properties:
-      - 'dc:description'
+      - 'dcterms:description'
   field_extent:
     properties:
-      - 'dc:extent'
+      - 'dcterms:extent'
   field_identifier:
     properties:
-      - 'dc:identifier'
+      - 'dcterms:identifier'
   field_member_of:
     properties:
       - 'pcdm:memberOf'
     mapping_type: rel
   field_resource_type:
     properties:
-      - 'dc:type'
+      - 'dcterms:type'
     mapping_type: rel
   field_rights:
     properties:
-      - 'dc:rights'
+      - 'dcterms:rights'
   field_subject:
     properties:
-      - 'dc:subject'
+      - 'dcterms:subject'
     mapping_type: rel
   field_language:
     properties:
@@ -76,13 +76,13 @@ fieldMappings:
       - 'dcterms:tableOfContents'
   field_dewey_classification:
     properties:
-      - 'dc:subject'
+      - 'dcterms:subject'
   field_lcc_classification:
     properties:
-      - 'dc:subject'
+      - 'dcterms:subject'
   field_subjects_name:
     properties:
-      - 'dc:subject'
+      - 'dcterms:subject'
   field_temporal_subject:
     properties:
       - 'dcterms:temporal'
@@ -106,7 +106,7 @@ fieldMappings:
       - 'co:index'
   title:
     properties:
-      - 'dc:title'
+      - 'dcterms:title'
   created:
     properties:
       - 'schema:dateCreated'

--- a/config/install/rdf.mapping.taxonomy_term.islandora_access.yml
+++ b/config/install/rdf.mapping.taxonomy_term.islandora_access.yml
@@ -16,10 +16,10 @@ types:
 fieldMappings:
   name:
     properties:
-      - 'dc:title'
+      - 'dcterms:title'
   description:
     properties:
-      - 'dc:description'
+      - 'dcterms:description'
   field_external_uri:
     properties:
       - 'owl:sameAs'

--- a/config/install/rdf.mapping.taxonomy_term.islandora_display.yml
+++ b/config/install/rdf.mapping.taxonomy_term.islandora_display.yml
@@ -16,10 +16,10 @@ types:
 fieldMappings:
   name:
     properties:
-      - 'dc:title'
+      - 'dcterms:title'
   description:
     properties:
-      - 'dc:description'
+      - 'dcterms:description'
   field_external_uri:
     properties:
       - 'owl:sameAs'

--- a/config/install/rdf.mapping.taxonomy_term.islandora_media_use.yml
+++ b/config/install/rdf.mapping.taxonomy_term.islandora_media_use.yml
@@ -16,10 +16,10 @@ types:
 fieldMappings:
   name:
     properties:
-      - 'dc:title'
+      - 'dcterms:title'
   description:
     properties:
-      - 'dc:description'
+      - 'dcterms:description'
   field_external_uri:
     properties:
       - 'owl:sameAs'

--- a/config/install/rdf.mapping.taxonomy_term.islandora_models.yml
+++ b/config/install/rdf.mapping.taxonomy_term.islandora_models.yml
@@ -16,10 +16,10 @@ types:
 fieldMappings:
   name:
     properties:
-      - 'dc:title'
+      - 'dcterms:title'
   description:
     properties:
-      - 'dc:description'
+      - 'dcterms:description'
   field_external_uri:
     properties:
       - 'owl:sameAs'


### PR DESCRIPTION
**GitHub Issue**: Relates to https://github.com/Islandora/documentation/issues/1412

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
This pull request simply changes the items using `dc` to using `dcterms` for consistency and hopefully clears up any confusion about dublin core namespaces. `dc` and `dcterms` point to the same namespace, just that `dcterms` is the prefix generally used to address the terms namespace.

Defined by islandora.module
   'dc11' => 'http://purl.org/dc/elements/1.1/'
   'dcterms' => 'http://purl.org/dc/terms/'

Defined by drupal:
   'dc => 'http://purl.org/dc/terms/'


# Interested parties
@seth-shaw-unlv @dannylamb @whikloj 