### PR TITLE
Initial search fields

### DIFF
--- a/modules/islandora_search/config/install/views.view.solr_search_content.yml
+++ b/modules/islandora_search/config/install/views.view.solr_search_content.yml
@@ -61,25 +61,12 @@ display:
       style:
         type: default
       row:
-        type: search_api
+        type: fields
         options:
-          view_modes:
-            'entity:node':
-              article: search_result
-              islandora_object: search_result
-              page: search_result
-            'entity:taxonomy_term':
-              corporate_body: default
-              family: default
-              genre: default
-              geo_location: default
-              language: default
-              person: default
-              physical_form: default
-              resource_types: default
-              subject: default
-              tags: default
-              temporal: default
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
       filters:
         type:
           id: type
@@ -167,7 +154,19 @@ display:
           min_length: null
           fields: {  }
           plugin_id: search_api_fulltext
-      sorts: {  }
+      sorts:
+        search_api_relevance:
+          id: search_api_relevance
+          table: search_api_index_default_solr_index
+          field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
       title: 'Search Content'
       header:
         result:
@@ -189,6 +188,126 @@ display:
         operator: AND
         groups:
           1: AND
+      fields:
+        search_api_rendered_item:
+          id: search_api_rendered_item
+          table: search_api_index_default_solr_index
+          field: search_api_rendered_item
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_modes:
+            'entity:node':
+              article: teaser
+              islandora_object: teaser
+              page: teaser
+            'entity:taxonomy_term':
+              corporate_body: default
+              family: default
+              genre: default
+              geo_location: default
+              language: default
+              person: default
+              physical_form: default
+              resource_types: default
+              subject: default
+              tags: default
+              temporal: default
+          plugin_id: search_api_rendered_item
+        search_api_excerpt:
+          id: search_api_excerpt
+          table: search_api_index_default_solr_index
+          field: search_api_excerpt
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          link_to_item: false
+          use_highlighting: true
+          multi_type: separator
+          multi_separator: ', '
+          plugin_id: search_api
     cache_metadata:
       contexts:
         - 'languages:language_interface'

--- a/modules/islandora_search/config/install/views.view.solr_search_content.yml
+++ b/modules/islandora_search/config/install/views.view.solr_search_content.yml
@@ -12,7 +12,6 @@ description: 'A search page preconfigured to search through the content of your 
 tag: ''
 base_table: search_api_index_default_solr_index
 base_field: search_api_id
-core: 8.x
 display:
   default:
     display_plugin: default
@@ -67,8 +66,20 @@ display:
           view_modes:
             'entity:node':
               article: search_result
-              islandora_object: teaser
+              islandora_object: search_result
               page: search_result
+            'entity:taxonomy_term':
+              corporate_body: default
+              family: default
+              genre: default
+              geo_location: default
+              language: default
+              person: default
+              physical_form: default
+              resource_types: default
+              subject: default
+              tags: default
+              temporal: default
       filters:
         type:
           id: type
@@ -95,6 +106,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -136,6 +149,8 @@ display:
               administrator: '0'
               fedoraadmin: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''

--- a/modules/islandora_search/config/optional/block.block.creatorsandcontributors.yml
+++ b/modules/islandora_search/config/optional/block.block.creatorsandcontributors.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.creators_and_contributors
+  module:
+    - facets
+    - system
+  theme:
+    - carapace
+id: creatorsandcontributors
+theme: carapace
+region: sidebar_second
+weight: 0
+provider: null
+plugin: 'facet_block:creators_and_contributors'
+settings:
+  id: 'facet_block:creators_and_contributors'
+  label: 'Creators and Contributors'
+  provider: facets
+  label_display: visible
+  block_id: creatorsandcontributors
+visibility:
+  request_path:
+    id: request_path
+    pages: /solr-search/content
+    negate: false
+    context_mapping: {  }

--- a/modules/islandora_search/config/optional/block.block.physicalform.yml
+++ b/modules/islandora_search/config/optional/block.block.physicalform.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.physical_form
+  module:
+    - facets
+    - system
+  theme:
+    - carapace
+id: physicalform
+theme: carapace
+region: sidebar_second
+weight: 0
+provider: null
+plugin: 'facet_block:physical_form'
+settings:
+  id: 'facet_block:physical_form'
+  label: 'Physical Form'
+  provider: facets
+  label_display: visible
+  block_id: physicalform
+visibility:
+  request_path:
+    id: request_path
+    pages: /solr-search/content
+    negate: false
+    context_mapping: {  }

--- a/modules/islandora_search/config/optional/block.block.subject.yml
+++ b/modules/islandora_search/config/optional/block.block.subject.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.subject
+  module:
+    - facets
+    - system
+  theme:
+    - carapace
+id: subject
+theme: carapace
+region: sidebar_second
+weight: 0
+provider: null
+plugin: 'facet_block:subject'
+settings:
+  id: 'facet_block:subject'
+  label: Subject
+  provider: facets
+  label_display: visible
+  block_id: subject
+visibility:
+  request_path:
+    id: request_path
+    pages: /solr-search/content
+    negate: false
+    context_mapping: {  }

--- a/modules/islandora_search/config/optional/block.block.subjectname.yml
+++ b/modules/islandora_search/config/optional/block.block.subjectname.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.subject_name
+  module:
+    - facets
+    - system
+  theme:
+    - carapace
+id: subjectname
+theme: carapace
+region: sidebar_second
+weight: 0
+provider: null
+plugin: 'facet_block:subject_name'
+settings:
+  id: 'facet_block:subject_name'
+  label: 'Subject (name)'
+  provider: facets
+  label_display: visible
+  block_id: subjectname
+visibility:
+  request_path:
+    id: request_path
+    pages: /solr-search/content
+    negate: false
+    context_mapping: {  }

--- a/modules/islandora_search/config/optional/block.block.temporalsubject.yml
+++ b/modules/islandora_search/config/optional/block.block.temporalsubject.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.temporal_subject
+  module:
+    - facets
+    - system
+  theme:
+    - carapace
+id: temporalsubject
+theme: carapace
+region: sidebar_second
+weight: 0
+provider: null
+plugin: 'facet_block:temporal_subject'
+settings:
+  id: 'facet_block:temporal_subject'
+  label: 'Temporal Subject'
+  provider: facets
+  label_display: visible
+  block_id: temporalsubject
+visibility:
+  request_path:
+    id: request_path
+    pages: /solr-search/content
+    negate: false
+    context_mapping: {  }

--- a/modules/islandora_search/config/optional/facets.facet.creators_and_contributors.yml
+++ b/modules/islandora_search/config/optional/facets.facet.creators_and_contributors.yml
@@ -1,0 +1,62 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: creators_and_contributors
+name: 'Creators and Contributors'
+url_alias: creators_and_contributors
+weight: -3
+min_count: 1
+show_only_one_result: false
+field_identifier: field_linked_agent
+facet_source_id: 'search_api:views_page__solr_search_content__page_1'
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: true
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: true
+query_operator: or
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: true

--- a/modules/islandora_search/config/optional/facets.facet.physical_form.yml
+++ b/modules/islandora_search/config/optional/facets.facet.physical_form.yml
@@ -1,0 +1,67 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: physical_form
+name: 'Physical Form'
+url_alias: physical_form
+weight: 1
+min_count: 1
+show_only_one_result: false
+field_identifier: field_physical_form
+facet_source_id: 'search_api:views_page__solr_search_content__page_1'
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: true
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: true
+query_operator: or
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_non_narrowing_result_processor:
+    processor_id: hide_non_narrowing_result_processor
+    weights:
+      build: 40
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/modules/islandora_search/config/optional/facets.facet.subject.yml
+++ b/modules/islandora_search/config/optional/facets.facet.subject.yml
@@ -1,0 +1,67 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: subject
+name: Subject
+url_alias: subject
+weight: -2
+min_count: 1
+show_only_one_result: false
+field_identifier: field_subject
+facet_source_id: 'search_api:views_page__solr_search_content__page_1'
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: true
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: true
+query_operator: or
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_non_narrowing_result_processor:
+    processor_id: hide_non_narrowing_result_processor
+    weights:
+      build: 40
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/modules/islandora_search/config/optional/facets.facet.subject_name.yml
+++ b/modules/islandora_search/config/optional/facets.facet.subject_name.yml
@@ -1,0 +1,67 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: subject_name
+name: 'Subject (name)'
+url_alias: subject_name
+weight: -1
+min_count: 1
+show_only_one_result: false
+field_identifier: field_subjects_name
+facet_source_id: 'search_api:views_page__solr_search_content__page_1'
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: true
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: true
+query_operator: or
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_non_narrowing_result_processor:
+    processor_id: hide_non_narrowing_result_processor
+    weights:
+      build: 40
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/modules/islandora_search/config/optional/facets.facet.temporal_subject.yml
+++ b/modules/islandora_search/config/optional/facets.facet.temporal_subject.yml
@@ -1,0 +1,67 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: temporal_subject
+name: 'Temporal Subject'
+url_alias: temporal_subject
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: field_temporal_subject
+facet_source_id: 'search_api:views_page__solr_search_content__page_1'
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: true
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: true
+query_operator: or
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_non_narrowing_result_processor:
+    processor_id: hide_non_narrowing_result_processor
+    weights:
+      build: 40
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/modules/islandora_search/config/optional/search_api.index.default_solr_index.yml
+++ b/modules/islandora_search/config/optional/search_api.index.default_solr_index.yml
@@ -8,15 +8,10 @@ dependencies:
     - taxonomy
     - search_api
   config:
-    - field.storage.taxonomy_term.field_person_alternate_names
-    - field.storage.taxonomy_term.field_cat_date_begin
-    - field.storage.taxonomy_term.field_cat_date_end
-    - field.storage.taxonomy_term.field_corp_alt_name
-    - field.storage.node.field_description
     - field.storage.node.field_edtf_date
     - field.storage.node.field_edtf_date_created
     - field.storage.node.field_edtf_date_issued
-    - field.storage.taxonomy_term.field_geo_alt_name
+    - field.storage.node.field_description
     - field.storage.node.field_identifier
     - field.storage.node.field_linked_agent
     - field.storage.node.field_local_identifier
@@ -28,6 +23,11 @@ dependencies:
     - field.storage.node.field_table_of_contents
     - field.storage.node.field_tags
     - field.storage.node.field_temporal_subject
+    - field.storage.taxonomy_term.field_geo_alt_name
+    - field.storage.taxonomy_term.field_corp_alt_name
+    - field.storage.taxonomy_term.field_cat_date_end
+    - field.storage.taxonomy_term.field_cat_date_begin
+    - field.storage.taxonomy_term.field_person_alternate_names
     - field.storage.taxonomy_term.field_person_preferred_name
     - search_api.server.default_solr_server
     - core.entity_view_mode.node.search_index
@@ -338,7 +338,20 @@ field_settings:
       view_mode:
         'entity:node':
           article: search_index
+          islandora_object: search_index
           page: search_index
+        'entity:taxonomy_term':
+          corporate_body: default
+          family: default
+          genre: default
+          geo_location: default
+          language: default
+          person: default
+          physical_form: default
+          resource_types: default
+          subject: default
+          tags: default
+          temporal: default
   status:
     label: 'Publishing status'
     datasource_id: 'entity:node'

--- a/modules/islandora_search/config/optional/search_api.index.default_solr_index.yml
+++ b/modules/islandora_search/config/optional/search_api.index.default_solr_index.yml
@@ -1,0 +1,448 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api_solr
+    - node
+    - user
+    - taxonomy
+    - search_api
+  config:
+    - field.storage.taxonomy_term.field_person_alternate_names
+    - field.storage.taxonomy_term.field_cat_date_begin
+    - field.storage.taxonomy_term.field_cat_date_end
+    - field.storage.taxonomy_term.field_corp_alt_name
+    - field.storage.node.field_description
+    - field.storage.node.field_edtf_date
+    - field.storage.node.field_edtf_date_created
+    - field.storage.node.field_edtf_date_issued
+    - field.storage.taxonomy_term.field_geo_alt_name
+    - field.storage.node.field_identifier
+    - field.storage.node.field_linked_agent
+    - field.storage.node.field_local_identifier
+    - field.storage.node.field_member_of
+    - field.storage.node.field_note
+    - field.storage.node.field_physical_form
+    - field.storage.node.field_subject
+    - field.storage.node.field_subjects_name
+    - field.storage.node.field_table_of_contents
+    - field.storage.node.field_tags
+    - field.storage.node.field_temporal_subject
+    - field.storage.taxonomy_term.field_person_preferred_name
+    - search_api.server.default_solr_server
+    - core.entity_view_mode.node.search_index
+third_party_settings:
+  search_api_solr:
+    finalize: false
+    commit_before_finalize: false
+    commit_after_finalize: false
+    highlighter:
+      maxAnalyzedChars: 51200
+      fragmenter: regex
+      regex:
+        slop: 0.5
+        pattern: blank
+        maxAnalyzedChars: 10000
+      usePhraseHighlighter: true
+      highlightMultiTerm: true
+      preserveMulti: false
+      highlight:
+        mergeContiguous: false
+        requireFieldMatch: false
+        snippets: 3
+        fragsize: 0
+    advanced:
+      index_prefix: ''
+id: default_solr_index
+name: 'Default Solr content index'
+description: 'Default content index created by the Solr Search Defaults module'
+read_only: false
+field_settings:
+  alternate_family_name:
+    label: 'Person Alternate Family Name'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: 'field_person_alternate_names:family'
+    type: string
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_person_alternate_names
+  alternate_given_name:
+    label: 'Person Alternate Given Name'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: 'field_person_alternate_names:given'
+    type: string
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_person_alternate_names
+  alternate_middle_name:
+    label: 'Person Alternate Middle Names'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: 'field_person_alternate_names:middle'
+    type: string
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_person_alternate_names
+  author:
+    label: 'Author name'
+    datasource_id: 'entity:node'
+    property_path: 'uid:entity:name'
+    type: string
+    dependencies:
+      module:
+        - node
+        - user
+        - user
+  changed:
+    label: Changed
+    datasource_id: 'entity:node'
+    property_path: changed
+    type: date
+    dependencies:
+      module:
+        - node
+  created:
+    label: 'Authored on'
+    datasource_id: 'entity:node'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - node
+  description:
+    label: Description
+    datasource_id: 'entity:taxonomy_term'
+    property_path: description
+    type: text
+    dependencies:
+      module:
+        - taxonomy
+  field_cat_date_begin:
+    label: 'Founding Date'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: field_cat_date_begin
+    type: string
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_cat_date_begin
+  field_cat_date_end:
+    label: 'Dissolution Date'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: field_cat_date_end
+    type: string
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_cat_date_end
+  field_corp_alt_name:
+    label: 'Corporate Body Alternate Name'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: field_corp_alt_name
+    type: text
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_corp_alt_name
+  field_description:
+    label: Description
+    datasource_id: 'entity:node'
+    property_path: field_description
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_description
+  field_edtf_date:
+    label: Date
+    datasource_id: 'entity:node'
+    property_path: field_edtf_date
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_edtf_date
+  field_edtf_date_created:
+    label: 'Date Created'
+    datasource_id: 'entity:node'
+    property_path: field_edtf_date_created
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_edtf_date_created
+  field_edtf_date_issued:
+    label: 'Date Issued'
+    datasource_id: 'entity:node'
+    property_path: field_edtf_date_issued
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_edtf_date_issued
+  field_geo_alt_name:
+    label: 'Alternate Name'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: field_geo_alt_name
+    type: text
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_geo_alt_name
+  field_identifier:
+    label: Identifier
+    datasource_id: 'entity:node'
+    property_path: field_identifier
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_identifier
+  field_linked_agent:
+    label: 'Linked Agent'
+    datasource_id: 'entity:node'
+    property_path: 'field_linked_agent:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_linked_agent
+      module:
+        - taxonomy
+        - taxonomy
+  field_local_identifier:
+    label: 'Local Identifier'
+    datasource_id: 'entity:node'
+    property_path: field_local_identifier
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_local_identifier
+  field_member_of:
+    label: 'Member of'
+    datasource_id: 'entity:node'
+    property_path: field_member_of
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_member_of
+  field_note:
+    label: Note
+    datasource_id: 'entity:node'
+    property_path: field_note
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_note
+  field_physical_form:
+    label: 'Physical Form'
+    datasource_id: 'entity:node'
+    property_path: 'field_physical_form:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_physical_form
+      module:
+        - taxonomy
+        - taxonomy
+  field_subject:
+    label: Subject
+    datasource_id: 'entity:node'
+    property_path: 'field_subject:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_subject
+      module:
+        - taxonomy
+        - taxonomy
+  field_subjects_name:
+    label: 'Subject (name)'
+    datasource_id: 'entity:node'
+    property_path: 'field_subjects_name:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_subjects_name
+      module:
+        - taxonomy
+        - taxonomy
+  field_table_of_contents:
+    label: 'Table of Contents'
+    datasource_id: 'entity:node'
+    property_path: field_table_of_contents
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_table_of_contents
+  field_tags:
+    label: Tags
+    datasource_id: 'entity:node'
+    property_path: field_tags
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_tags
+  field_temporal_subject:
+    label: 'Temporal Subject'
+    datasource_id: 'entity:node'
+    property_path: 'field_temporal_subject:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_temporal_subject
+      module:
+        - taxonomy
+        - taxonomy
+  name:
+    label: Name
+    datasource_id: 'entity:taxonomy_term'
+    property_path: name
+    type: text
+    boost: !!float 8
+    dependencies:
+      module:
+        - taxonomy
+  node_grants:
+    label: 'Node access information'
+    property_path: search_api_node_grants
+    type: string
+    indexed_locked: true
+    type_locked: true
+    hidden: true
+  preferred_family_name:
+    label: 'Person Preferred Family Name'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: 'field_person_preferred_name:family'
+    type: string
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_person_preferred_name
+  preferred_given_name:
+    label: 'Person Preferred Given Name'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: 'field_person_preferred_name:given'
+    type: string
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_person_preferred_name
+  preferred_middle_name:
+    label: 'Person Preferred Middle Names'
+    datasource_id: 'entity:taxonomy_term'
+    property_path: 'field_person_preferred_name:middle'
+    type: string
+    dependencies:
+      config:
+        - field.storage.taxonomy_term.field_person_preferred_name
+  rendered_item:
+    label: 'Rendered item'
+    property_path: rendered_item
+    type: text
+    configuration:
+      roles:
+        anonymous: anonymous
+      view_mode:
+        'entity:node':
+          article: search_index
+          page: search_index
+  status:
+    label: 'Publishing status'
+    datasource_id: 'entity:node'
+    property_path: status
+    type: boolean
+    indexed_locked: true
+    type_locked: true
+    dependencies:
+      module:
+        - node
+  sticky:
+    label: 'Sticky at top of lists'
+    datasource_id: 'entity:node'
+    property_path: sticky
+    type: boolean
+    dependencies:
+      module:
+        - node
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: text
+    boost: !!float 8
+    dependencies:
+      module:
+        - node
+  type:
+    label: 'Content type'
+    datasource_id: 'entity:node'
+    property_path: type
+    type: string
+    dependencies:
+      module:
+        - node
+  uid:
+    label: 'Author ID'
+    datasource_id: 'entity:node'
+    property_path: uid
+    type: integer
+    indexed_locked: true
+    type_locked: true
+    dependencies:
+      module:
+        - node
+datasource_settings:
+  'entity:node':
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+  'entity:taxonomy_term':
+    bundles:
+      default: true
+      selected:
+        - islandora_access
+        - islandora_display
+        - islandora_media_use
+        - islandora_models
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url:
+    weights:
+      preprocess_index: -30
+  aggregated_field:
+    weights:
+      add_properties: 20
+  content_access:
+    weights:
+      preprocess_index: -6
+      preprocess_query: -4
+  entity_status:
+    weights:
+      preprocess_index: -10
+  hierarchy:
+    fields:
+      field_member_of: node-field_member_of
+    weights:
+      preprocess_index: -45
+  html_filter:
+    all_fields: false
+    fields:
+      - rendered_item
+    title: true
+    alt: true
+    tags:
+      b: 2
+      h1: 5
+      h2: 3
+      h3: 2
+      string: 2
+    weights:
+      preprocess_index: -3
+      preprocess_query: -6
+  rendered_item:
+    weights:
+      add_properties: 0
+      pre_index_save: -10
+  solr_date_range:
+    weights:
+      preprocess_index: 0
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: true
+  cron_limit: 50
+server: default_solr_server

--- a/modules/islandora_search/config/optional/search_api.index.default_solr_index.yml
+++ b/modules/islandora_search/config/optional/search_api.index.default_solr_index.yml
@@ -8,15 +8,10 @@ dependencies:
     - taxonomy
     - search_api
   config:
-    - field.storage.taxonomy_term.field_person_alternate_names
-    - field.storage.taxonomy_term.field_cat_date_begin
-    - field.storage.taxonomy_term.field_cat_date_end
-    - field.storage.taxonomy_term.field_corp_alt_name
-    - field.storage.node.field_description
     - field.storage.node.field_edtf_date
     - field.storage.node.field_edtf_date_created
     - field.storage.node.field_edtf_date_issued
-    - field.storage.taxonomy_term.field_geo_alt_name
+    - field.storage.node.field_description
     - field.storage.node.field_identifier
     - field.storage.node.field_linked_agent
     - field.storage.node.field_local_identifier
@@ -28,6 +23,11 @@ dependencies:
     - field.storage.node.field_table_of_contents
     - field.storage.node.field_tags
     - field.storage.node.field_temporal_subject
+    - field.storage.taxonomy_term.field_geo_alt_name
+    - field.storage.taxonomy_term.field_corp_alt_name
+    - field.storage.taxonomy_term.field_cat_date_end
+    - field.storage.taxonomy_term.field_cat_date_begin
+    - field.storage.taxonomy_term.field_person_alternate_names
     - field.storage.taxonomy_term.field_person_preferred_name
     - search_api.server.default_solr_server
     - core.entity_view_mode.node.search_index
@@ -148,6 +148,11 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_description
+  field_edited_text:
+    label: 'Edited Text'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_media__field_media_of:field_edited_text'
+    type: text
   field_edtf_date:
     label: Date
     datasource_id: 'entity:node'
@@ -436,6 +441,7 @@ processor_settings:
     weights:
       add_properties: 0
       pre_index_save: -10
+  reverse_entity_references: {  }
   solr_date_range:
     weights:
       preprocess_index: 0

--- a/modules/islandora_search/config/optional/search_api.index.default_solr_index.yml
+++ b/modules/islandora_search/config/optional/search_api.index.default_solr_index.yml
@@ -8,10 +8,15 @@ dependencies:
     - taxonomy
     - search_api
   config:
+    - field.storage.taxonomy_term.field_person_alternate_names
+    - field.storage.taxonomy_term.field_cat_date_begin
+    - field.storage.taxonomy_term.field_cat_date_end
+    - field.storage.taxonomy_term.field_corp_alt_name
+    - field.storage.node.field_description
     - field.storage.node.field_edtf_date
     - field.storage.node.field_edtf_date_created
     - field.storage.node.field_edtf_date_issued
-    - field.storage.node.field_description
+    - field.storage.taxonomy_term.field_geo_alt_name
     - field.storage.node.field_identifier
     - field.storage.node.field_linked_agent
     - field.storage.node.field_local_identifier
@@ -23,11 +28,6 @@ dependencies:
     - field.storage.node.field_table_of_contents
     - field.storage.node.field_tags
     - field.storage.node.field_temporal_subject
-    - field.storage.taxonomy_term.field_geo_alt_name
-    - field.storage.taxonomy_term.field_corp_alt_name
-    - field.storage.taxonomy_term.field_cat_date_end
-    - field.storage.taxonomy_term.field_cat_date_begin
-    - field.storage.taxonomy_term.field_person_alternate_names
     - field.storage.taxonomy_term.field_person_preferred_name
     - search_api.server.default_solr_server
     - core.entity_view_mode.node.search_index
@@ -422,6 +422,17 @@ processor_settings:
       field_member_of: node-field_member_of
     weights:
       preprocess_index: -45
+  highlight:
+    highlight: always
+    highlight_partial: true
+    excerpt: true
+    excerpt_length: 256
+    exclude_fields:
+      - rendered_item
+    prefix: '<strong>'
+    suffix: '</strong>'
+    weights:
+      postprocess_query: 0
   html_filter:
     all_fields: false
     fields:

--- a/modules/islandora_search/config/optional/search_api.server.default_solr_server.yml
+++ b/modules/islandora_search/config/optional/search_api.server.default_solr_server.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api_solr.solr_field_type.text_phonetic_und_7_0_0
+    - search_api_solr.solr_field_type.text_und_7_0_0
+  module:
+    - search_api_solr
+id: default_solr_server
+name: 'Solr Server'
+description: 'Default Solr server created by the Solr Search Defaults module'
+backend: search_api_solr
+backend_config:
+  connector: standard
+  connector_config:
+    scheme: http
+    host: 127.0.0.1
+    port: '8983'
+    path: /solr
+    core: ISLANDORA
+    timeout: 5
+    index_timeout: 10
+    optimize_timeout: 15
+    finalize_timeout: 30
+    commit_within: 1000
+    solr_version: ''
+    http_method: AUTO
+    jmx: false
+  retrieve_data: false
+  highlight_data: false
+  skip_schema_check: false
+  domain: generic
+  site_hash: true
+  server_prefix: ''

--- a/modules/islandora_search/islandora_search.features.yml
+++ b/modules/islandora_search/islandora_search.features.yml
@@ -1,1 +1,4 @@
 bundle: islandora
+required:
+  - search_api.index.default_solr_index
+  - search_api.server.default_solr_server

--- a/modules/islandora_search/islandora_search.info.yml
+++ b/modules/islandora_search/islandora_search.info.yml
@@ -2,8 +2,13 @@ name: 'Islandora Search'
 type: module
 description: 'Default configuration for Islandora search'
 core: 8.x
-package: 'Islandora'
+package: Islandora
 dependencies:
   - block
-  - search_api_solr_defaults
+  - controlled_access_terms_defaults
+  - islandora_core_feature
   - islandora_defaults
+  - search_api
+  - search_api_solr_defaults
+  - views
+core_incompatible: false

--- a/modules/islandora_search/islandora_search.info.yml
+++ b/modules/islandora_search/islandora_search.info.yml
@@ -5,10 +5,13 @@ core: 8.x
 package: Islandora
 dependencies:
   - block
+  - controlled_access_terms
   - controlled_access_terms_defaults
   - islandora_core_feature
   - islandora_defaults
   - search_api
   - search_api_solr_defaults
+  - text
+  - user
   - views
 core_incompatible: false


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/940

https://islandora.slack.com/archives/CM5PPAV28/p1580748598486600

# What does this Pull Request do?

Adds a default search config.

# What's new?

* Added a default server and index config.
* Does this change require documentation to be updated? I don't think so.
* Does this change add any new dependencies? Not yet (we may add a facet block based on PR feedback).
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? Re-index Solr (`drush search-api-reindex`)
* Could this change impact execution of existing code? No.

# How should this be tested?

* Generate some content and search for it: _only titles return any results_
* Apply the PR and import the Islandora Search Feature
* Re-index (`drush search-api-reindex`) OR hit 'Index Now' @ `http://localhost:8000/admin/config/search/search-api/index/default_solr_index`
* Wait for re-index to complete
* Search for stuff: _not only will items show up based on descriptions, but you will also get Agent and Subjects showing up as results, too._

# Additional Notes:
I'm willing to throw in facets while I'm at it. I just need suggestions as to reasonable default options and if I should aggregate any of them (e.g. should 'subject' and 'subject (name)' be the same facet?). 

# Interested parties
@Islandora/8-x-committers and MIG folks (@mbolam and @rtilla1)
