### PR TITLE
Adds digital document thumbnail action so it can generate thumbnail correctly

### DIFF
--- a/config/install/context.context.pdf_original_file.yml
+++ b/config/install/context.context.pdf_original_file.yml
@@ -27,6 +27,6 @@ reactions:
     id: derivative
     actions:
       get_ocr_from_image: get_ocr_from_image
-      image_generate_a_thumbnail_from_an_original_file: image_generate_a_thumbnail_from_an_original_file
+      image_generate_a_thumbnail_from_an_original_file:  digital_document_generate_a_thumbnail_from_an_original_file
     saved: false
 weight: -6

--- a/config/install/system.action.digital_document_generate_a_thumbnail_from_an_original_file.yml
+++ b/config/install/system.action.digital_document_generate_a_thumbnail_from_an_original_file.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - islandora_image
+id: digital_document_generate_a_thumbnail_from_an_original_file
+label: 'Digital Document - Generate a thumbnail from an original file'
+type: node
+plugin: generate_image_derivative
+configuration:
+  queue: islandora-connector-houdini
+  event: 'Generate Derivative'
+  source_term_uri: 'http://pcdm.org/use#OriginalFile'
+  derivative_term_uri: 'http://pcdm.org/use#ThumbnailImage'
+  mimetype: image/png
+  args: '-thumbnail 100x100'
+  destination_media_type: image
+  scheme: public
+  path: '[date:custom:Y]-[date:custom:m]/[node:nid]-[term:name].png'


### PR DESCRIPTION

**GitHub Issue**: https://github.com/Islandora/documentation/issues/1260

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

This makes the thumbnail generated for a pdf into a png, versus jpg. This makes it so all layers in pdf are visible in thumbnail, versus just one. 

# What's new?
This change simply adds a new action to generate digital document thumbnails as png files. 

* Adds file system.action.digital_document_generate_a_thumbnail_from_an_original_file.yml
* Changes context.context.pdf_original_file.yml to use new action versus one for an image. 

# How should this be tested?
First find a PDF file with a jpg image embedded in it.  Load it into islandora and notice that the thumbnail only pulled the image layer and the background is black. 

Then put these changed files into the proper directory `/var/www/html/drupal/web/modules/contrib/islandora_defaults/config/install` in your VM.  Then use the features interface to load/reload the files. 

* http://localhost:8000/admin/config/development/features --> click on `Changed` in the row for `Islandora Defaults`. 
* Click on the square to `choose context.context.pdf_original_file` and `system.action.digital_document_generate_a_thumbnail_from_an_original_file`, then click on `Import Changes` at the bottom. 
* Add the same PDF as a new object (or re-run the action for the derivative) and you should see the thumbnail now looks correct.
* Under Admin->Structure->Context-> PDF Original File in the Actions box you'll notice that the action selected is now  `Digital Document - Generates a thumbnail from an original file"


# Interested parties
@dannylamb @Islandora/8-x-committers
