### PR TITLE
Issue-1463: remove solr server path config

### DIFF
--- a/modules/islandora_search/config/optional/search_api.server.default_solr_server.yml
+++ b/modules/islandora_search/config/optional/search_api.server.default_solr_server.yml
@@ -16,7 +16,6 @@ backend_config:
     scheme: http
     host: 127.0.0.1
     port: '8983'
-    path: /solr
     core: ISLANDORA
     timeout: 5
     index_timeout: 10


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1463

Merge **AFTER** https://github.com/Islandora-Devops/islandora-playbook/pull/157

# What does this Pull Request do?

Drops the solr server path config for compatibility with search_api_solr:3.8

# What's new?
* Removed solr server path config
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

**After https://github.com/Islandora-Devops/islandora-playbook/pull/157 merges**
- Spin up a new playbook
- Search API settings (`http://localhost:8000/admin/config/search/search-api/server/default_solr_server`) will be happy, but nothing is searchable. ☹️ (See https://github.com/Islandora/documentation/issues/1452 for more details.)
- Import the islandora_search feature (`drush fim -y islandora_search` OR `http://localhost:8000/admin/config/development/features/diff/islandora_search`)
- Search API Solr Server (`http://localhost:8000/admin/config/search/search-api/server/default_solr_server`) is now broken! 🤕
- Apply the PR
- Import the islandora_search feature **again** (`drush fim -y islandora_search` OR `http://localhost:8000/admin/config/development/features/diff/islandora_search`).
- Search API Solr Server (`http://localhost:8000/admin/config/search/search-api/server/default_solr_server`) is now connecting as searching works!  🎉

# Interested parties
@Islandora/8-x-committers, esp @elizoller, @kayakr, and @dannylamb 
