### PR TITLE
Islandora-ize Document media type (Issue 1459)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 branches:
   only:
-    - /^8.x/
+    - /^8.8.x/
     - /master/
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 branches:
   only:
-    - /^8.8.x/
+    - /^8.x/
     - /master/
 
 before_install:

--- a/config/install/context.context.all_media.yml
+++ b/config/install/context.context.all_media.yml
@@ -14,6 +14,7 @@ conditions:
     id: entity_bundle
     bundles:
       audio: audio
+      document: document
       extracted_text: extracted_text
       file: file
       image: image

--- a/config/install/core.entity_form_display.media.document.default.yml
+++ b/config/install/core.entity_form_display.media.document.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - field.field.media.document.field_original_name
     - media.type.document
   module:
-    - document
+    - file
     - path
 id: media.document.default
 targetEntityType: media

--- a/config/install/core.entity_form_display.media.document.default.yml
+++ b/config/install/core.entity_form_display.media.document.default.yml
@@ -34,7 +34,7 @@ content:
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
-    type: document_generic
+    type: file_generic
     weight: 1
     region: content
   field_media_of:

--- a/config/install/core.entity_form_display.media.document.default.yml
+++ b/config/install/core.entity_form_display.media.document.default.yml
@@ -1,0 +1,101 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.document.field_access_terms
+    - field.field.media.document.field_file_size
+    - field.field.media.document.field_media_document
+    - field.field.media.document.field_media_of
+    - field.field.media.document.field_media_use
+    - field.field.media.document.field_mime_type
+    - field.field.media.document.field_original_name
+    - media.type.document
+  module:
+    - document
+    - path
+id: media.document.default
+targetEntityType: media
+bundle: document
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_access_terms:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_media_document:
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: document_generic
+    weight: 1
+    region: content
+  field_media_of:
+    type: entity_reference_autocomplete
+    weight: 4
+    region: content
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_media_use:
+    type: options_buttons
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_original_name:
+    weight: 26
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 8
+    region: content
+    third_party_settings: {  }
+  translation:
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden:
+  field_file_size: true
+  field_mime_type: true
+  langcode: true

--- a/config/install/core.entity_view_display.media.document.default.yml
+++ b/config/install/core.entity_view_display.media.document.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - field.field.media.document.field_original_name
     - media.type.document
   module:
-    - document
+    - file 
 id: media.document.default
 targetEntityType: media
 bundle: document

--- a/config/install/core.entity_view_display.media.document.default.yml
+++ b/config/install/core.entity_view_display.media.document.default.yml
@@ -1,0 +1,93 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.document.field_access_terms
+    - field.field.media.document.field_file_size
+    - field.field.media.document.field_media_document
+    - field.field.media.document.field_media_of
+    - field.field.media.document.field_media_use
+    - field.field.media.document.field_mime_type
+    - field.field.media.document.field_original_name
+    - media.type.document
+  module:
+    - document
+id: media.document.default
+targetEntityType: media
+bundle: document
+mode: default
+content:
+  field_access_terms:
+    weight: 6
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_file_size:
+    type: number_integer
+    weight: 3
+    region: content
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+  field_gemini_uri:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_media_document:
+    label: visually_hidden
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    type: document_default
+    weight: 1
+    region: content
+  field_media_of:
+    type: entity_reference_label
+    weight: 4
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_media_use:
+    type: entity_reference_label
+    weight: 5
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_mime_type:
+    type: string
+    weight: 2
+    region: content
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_original_name:
+    weight: 101
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  name:
+    type: string
+    weight: 0
+    region: content
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  created: true
+  langcode: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.document.default.yml
+++ b/config/install/core.entity_view_display.media.document.default.yml
@@ -44,7 +44,7 @@ content:
     settings:
       use_description_as_link_text: true
     third_party_settings: {  }
-    type: document_default
+    type: file_default
     weight: 1
     region: content
   field_media_of:

--- a/config/install/core.entity_view_display.media.document.pdfjs.yml
+++ b/config/install/core.entity_view_display.media.document.pdfjs.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.pdfjs
+    - field.field.media.document.field_access_terms
+    - field.field.media.document.field_file_size
+    - field.field.media.document.field_media_document
+    - field.field.media.document.field_media_of
+    - field.field.media.document.field_media_use
+    - field.field.media.document.field_mime_type
+    - field.field.media.document.field_original_name
+    - media.type.document
+  module:
+    - pdf
+id: media.document.pdfjs
+targetEntityType: media
+bundle: document
+mode: pdfjs
+content:
+  field_media_document:
+    type: pdf_default
+    weight: 0
+    region: content
+    label: visually_hidden
+    settings:
+      keep_pdfjs: '1'
+      width: 100%
+      height: 640px
+      page: ''
+      zoom: ''
+      custom_zoom: ''
+      pagemode: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_access_terms: true
+  field_file_size: true
+  field_gemini_uri: true
+  field_media_of: true
+  field_media_use: true
+  field_mime_type: true
+  field_original_name: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.document.source.yml
+++ b/config/install/core.entity_view_display.media.document.source.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.source
+    - field.field.media.document.field_access_terms
+    - field.field.media.document.field_file_size
+    - field.field.media.document.field_media_document
+    - field.field.media.document.field_media_of
+    - field.field.media.document.field_media_use
+    - field.field.media.document.field_mime_type
+    - field.field.media.document.field_original_name
+    - media.type.document
+  enforced:
+    module:
+      - islandora_core_feature
+  module:
+    - file
+id: media.document.source
+targetEntityType: media
+bundle: document
+mode: source
+content:
+  field_media_document:
+    label: hidden
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    type: file_default
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_access_terms: true
+  field_file_size: true
+  field_gemini_uri: true
+  field_media_of: true
+  field_media_use: true
+  field_mime_type: true
+  field_original_name: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/field.field.media.document.field_access_terms.yml
+++ b/config/install/field.field.media.document.field_access_terms.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_access_terms
+    - media.type.document
+    - taxonomy.vocabulary.islandora_access
+id: media.document.field_access_terms
+field_name: field_access_terms
+entity_type: media
+bundle: document
+label: 'Access terms'
+description: 'Terms that define who has access to view/edit this resource.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.media.document.field_file_size.yml
+++ b/config/install/field.field.media.document.field_file_size.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_file_size
+    - media.type.document
+  enforced:
+    module:
+      - islandora_core_feature
+id: media.document.field_file_size
+field_name: field_file_size
+entity_type: media
+bundle: document
+label: 'File size'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/install/field.field.media.document.field_media_of.yml
+++ b/config/install/field.field.media.document.field_media_of.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_of
+    - media.type.document
+  enforced:
+    module:
+      - islandora_core_feature
+id: media.document.field_media_of
+field_name: field_media_of
+entity_type: media
+bundle: document
+label: 'Media of'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/install/field.field.media.document.field_media_use.yml
+++ b/config/install/field.field.media.document.field_media_use.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_use
+    - media.type.document
+    - taxonomy.vocabulary.islandora_media_use
+id: media.document.field_media_use
+field_name: field_media_use
+entity_type: media
+bundle: document
+label: 'Media Use'
+description: 'Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. ''Original File'' will trigger creation of derivatives.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_media_use: islandora_media_use
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.media.document.field_mime_type.yml
+++ b/config/install/field.field.media.document.field_mime_type.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_mime_type
+    - media.type.document
+  enforced:
+    module:
+      - islandora_core_feature
+id: media.document.field_mime_type
+field_name: field_mime_type
+entity_type: media
+bundle: document
+label: 'MIME type'
+description: 'MIME type of the underlying file'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.field.media.document.field_original_name.yml
+++ b/config/install/field.field.media.document.field_original_name.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_original_name
+    - media.type.document
+id: media.document.field_original_name
+field_name: field_original_name
+entity_type: media
+bundle: document
+label: 'Original Name'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/media.type.document.yml
+++ b/config/install/media.type.document.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - islandora_core_feature
+id: document
+label: Document
+description: 'Use local documents for reusable media.'
+source: document
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_document
+field_map:
+  name: name
+  mimetype: field_mime_type
+  filesize: field_file_size

--- a/config/install/media.type.document.yml
+++ b/config/install/media.type.document.yml
@@ -6,8 +6,8 @@ dependencies:
       - islandora_core_feature
 id: document
 label: Document
-description: 'Use local documents for reusable media.'
-source: document
+description: 'An uploaded file or document, such as a PDF.'
+source: file
 queue_thumbnail_downloads: false
 new_revision: true
 source_configuration:

--- a/config/install/rdf.mapping.media.document.yml
+++ b/config/install/rdf.mapping.media.document.yml
@@ -1,0 +1,51 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.document
+  enforced:
+    module:
+      - islandora_core_feature
+  module:
+    - media
+id: media.document
+targetEntityType: media
+bundle: document
+types:
+  - 'pcdm:File'
+fieldMappings:
+  name:
+    properties:
+      - 'dcterms:title'
+      - 'rdf:label'
+  created:
+    properties:
+      - 'schema:dateCreated'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  changed:
+    properties:
+      - 'schema:dateModified'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  uid:
+    properties:
+      - 'schema:author'
+    mapping_type: rel
+  field_mime_type:
+    properties:
+      - 'ebucore:hasMimeType'
+  field_media_of:
+    properties:
+      - 'pcdm:fileOf'
+    mapping_type: rel
+  field_original_name:
+    properties:
+      - 'premis3:originalName'
+  field_tags:
+    properties:
+      - 'schema:additionalType'
+    mapping_type: rel
+  field_file_size:
+    properties:
+      - 'premis:hasSize'


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora/documentation/issues/1459

# What does this Pull Request do?

Adds the necessary configs to use the Document media type just like the File media type.

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Added
    * Document to 'All Media' context
    * All the Islandora Media fields to Document
    * A default, PDFjs, and source display modes for Document
    * A default form view for Document
    * An RDF mapping for Document
* Does this change require documentation to be updated? I don't think so.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

- Attempt to add a Document media and notice there are none of the usual Islandora fields (e.g. Media Of or Media Use).
- Apply the PR
- Import the Feature
- Attempt to add a Document media again and see all the usual fields. Creating the media will make it appear in Fedora as usual. 
- *Bonus* upload a PDF as a Document media (use can select both 'Original File' & 'Service File') and use the PDFjs display hint on the linked node to see your PDF show up in the PDFjs viewer.

# Additional Comments

Please squash when you merge. Thanks.

# Interested parties
@bseeger and @Islandora/8-x-committers
