### PR TITLE
Bump travis to 8.8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 branches:
   only:
-    - /^8.x/
+    - /^8.8.x/
     - /master/
 
 before_install:


### PR DESCRIPTION
**GitHub Issue**: n/a

Trying to get #26 to build...

# What does this Pull Request do?

Bumps to travis version to Drupal 8.8.x.

# What's new?

* Changes travis' Drupal version from 8.x to 8.8.x
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

Travis is green? 🤷‍♂ 

# Interested parties
@Islandora/8-x-committers, esp @dannylamb 
