### PR TITLE
Issue 1470

### DIFF
--- a/config/install/context.context.all_media.yml
+++ b/config/install/context.context.all_media.yml
@@ -10,8 +10,8 @@ description: 'All media, regardless of where it lives'
 requireAllConditions: false
 disabled: false
 conditions:
-  entity_bundle:
-    id: entity_bundle
+  islandora_entity_bundle:
+    id: islandora_entity_bundle
     bundles:
       audio: audio
       document: document


### PR DESCRIPTION
**GitHub Issue**: Part of islandora/documentation#1470 along with https://github.com/Islandora/islandora/pull/772

# What does this Pull Request do?

Uses `islandora_entity_bundle` instead of  `entity_bundle` to avoid an id collision with `ctools`.

# How should this be tested?

Folks really should test https://github.com/Islandora/islandora/pull/772.  This PR will just give new sites the `islandora_entity_bundle` condition instead of the old `entity_bundle` which collides with ctools.

# Interested parties
@Islandora/8-x-committers
