### PR TITLE
Adresses #1514.

### DIFF
--- a/config/install/field.field.node.islandora_object.field_pid.yml
+++ b/config/install/field.field.node.islandora_object.field_pid.yml
@@ -9,7 +9,7 @@ field_name: field_pid
 entity_type: node
 bundle: islandora_object
 label: PID
-description: ''
+description: 'PID of this object in Islandora 7.x (applies to migrated objects only).'
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.node.islandora_object.field_pid.yml
+++ b/config/install/field.field.node.islandora_object.field_pid.yml
@@ -9,7 +9,7 @@ field_name: field_pid
 entity_type: node
 bundle: islandora_object
 label: PID
-description: 'PID of this object in Islandora 7.x (applies to migrated objects only).'
+description: 'Persistent Identifier (PID) of this object in Islandora 7.x (applies to migrated objects only).'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1514

# What does this Pull Request do?

Adds the following description (a.k.a help text) to the Repository Item content type's PID field: "PID of this object in Islandora 7.x (applies to migrated objects only)."

# What's new?

Just the description/help text. However, note that testing this PR requires resetting all of the default configuration provided by Islandora Defaults. This is... most of the default configuration we provide. Therefore, this PR should *not* be tested on a live Islandora repository, or on one where you have made any (or important) changes to the default configuration provided by Islandora Defaults.

# How should this be tested?

1. Read the text above regarding resetting all of your configuration.
1. Check out this branch
   1. In the islandora_defaults directory, run `git remote add mjordan https://github.com/mjordan/islandora_defaults.git`
   1. Run `git fetch mjordan`
   1. Run `git checkout issue-1514`
1. Run `cd /var/www/html/drupal/web`
1. Run `drush cim --partial --source=modules/contrib/islandora_defaults/config/install/`. This is the command that resets the default configuration provided by Islandora Defaults.
1. In your web browser, visit `http://localhost:8000/node/add/islandora_object`.
1. Scroll to the bottom of the node add form. The PID field should have the following help text: "PID of this object in Islandora 7.x (applies to migrated objects only). "

# Interested parties
@Islandora/8-x-committers
