### PR TITLE
Mirador patch

### DIFF
--- a/migrate/tags.csv
+++ b/migrate/tags.csv
@@ -1,7 +1,6 @@
 vid,name,description,external_uri
 islandora_display,"Open Seadragon","Display using the Open Seadragon viewer",http://openseadragon.github.io
 islandora_display,"PDFjs","Display using the PDF.js viewer",http://mozilla.github.io/pdf.js
-islandora_display,"Mirador","Display using the Mirador viewer",https://projectmirador.org
 resource_types,"Collection","An aggregation of resources",http://purl.org/dc/dcmitype/Collection
 resource_types,"Dataset","Data encoded in a defined structure",http://purl.org/dc/dcmitype/Dataset
 resource_types,"Image","A visual representation other than text",http://purl.org/dc/dcmitype/Image

--- a/modules/islandora_mirador/config/install/context.context.mirador.yml
+++ b/modules/islandora_mirador/config/install/context.context.mirador.yml
@@ -13,9 +13,6 @@ conditions:
   node_has_term:
     id: node_has_term
     negate: 0
-    tids:
-      -
-        target_id: '31'
     uri: 'https://projectmirador.org'
     context_mapping:
       node: '@node.node_route_context:node'

--- a/modules/islandora_mirador/islandora_mirador.install
+++ b/modules/islandora_mirador/islandora_mirador.install
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Install/update hook implementations.
+ */
+
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Implements hook_install().
+ */
+function islandora_mirador_install() {
+  _get_or_create_tag();
+}
+
+/**
+ * Implements hook_update().
+ */
+function islandora_mirador_update_8001() {
+  _get_or_create_tag();
+}
+
+/**
+ * Looks up or creates Mirador term.
+ */
+function _get_or_create_tag() {
+  $term_name = 'Mirador';
+  $test_terms = taxonomy_term_load_multiple_by_name($term_name);
+  if (!$test_terms) {
+    $term = Term::create([
+      'parent' => [],
+      'name' => $term_name,
+      'vid' => 'islandora_display',
+      'description' => 'Display using the Mirador viewer',
+      'field_external_uri' => ['uri' => 'https://projectmirador.org'],
+    ])->save();
+  }
+}

--- a/modules/islandora_mirador/src/Plugin/Block/MiradorBlock.php
+++ b/modules/islandora_mirador/src/Plugin/Block/MiradorBlock.php
@@ -97,7 +97,9 @@ class MiradorBlock extends BlockBase implements ContainerFactoryPluginInterface 
    * {@inheritdoc}
    */
   public function blockSubmit($form, FormStateInterface $form_state) {
-    $this->configuration['iiif_manifest_url'] = $form_state->getValue(['iiif_manifest_url_fieldset', 'iiif_manifest_url']);
+    $this->configuration['iiif_manifest_url'] = $form_state->getValue(
+      ['iiif_manifest_url_fieldset', 'iiif_manifest_url']
+    );
   }
 
   /**


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora/documentation/issues/1608)


# What does this Pull Request do?

Moves the "Mirador" display hint to the islandora_mirador submodule

# What's new?
* removes "Mirador" term from the migrate in the main part of islandora_defaults
* adds an install and an update hook to add the term if it doesn't exist

# How should this be tested?
* install a regular islandora-playbook
* be sure you have no vestiges of islandora_mirador (including the term in the Islandora Display vocabulary)
* install islandora_mirador submodule
* check that you now have a term "Mirador"

# Interested parties
@Islandora/8-x-committers
@mjordan 
@kayakr 
@seth-shaw-unlv 
