### PR TITLE
Issue 1561: Remove dependency on Name module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH require "islandora/islandora_defaults:dev-travis-testing as dev-8.x-1.x" --prefer-source --update-with-dependencies
   - cd web;
   - drush -y --uri=127.0.0.1:8282 en islandora_search
-  - drush -y --uri=127.0.0.1:8282 fim islandora_core_feature,controlled_access_terms_defaults,islandora_defaults,islandora_search
+  - drush -y --uri=127.0.0.1:8282 fim islandora_core_feature,islandora_defaults,islandora_search
 
 script:
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "islandora/islandora": "dev-8.x-1.x",
     "islandora/openseadragon" : "dev-8.x-1.x",
-    "islandora/controlled_access_terms" : "dev-issue-1561",
+    "islandora/controlled_access_terms" : "dev-8.x-1.x",
     "drupal/field_group" : "^3.0",
     "drupal/permissions_by_term" : "^1.51",
     "drupal/field_permissions" : "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "islandora/islandora": "dev-8.x-1.x",
     "islandora/openseadragon" : "dev-8.x-1.x",
-    "islandora/controlled_access_terms" : "dev-8.x-1.x",
+    "islandora/controlled_access_terms" : "dev-issue-1561",
     "drupal/field_group" : "^3.0",
     "drupal/permissions_by_term" : "^1.51",
     "drupal/field_permissions" : "^1.0"

--- a/modules/islandora_search/config/install/search_api.index.default_solr_index.yml
+++ b/modules/islandora_search/config/install/search_api.index.default_solr_index.yml
@@ -27,8 +27,6 @@ dependencies:
     - field.storage.taxonomy_term.field_corp_alt_name
     - field.storage.taxonomy_term.field_cat_date_end
     - field.storage.taxonomy_term.field_cat_date_begin
-    - field.storage.taxonomy_term.field_person_alternate_names
-    - field.storage.taxonomy_term.field_person_preferred_name
     - search_api.server.default_solr_server
     - core.entity_view_mode.node.search_index
 third_party_settings:
@@ -58,30 +56,6 @@ name: 'Default Solr content index'
 description: 'Default content index created by the Solr Search Defaults module'
 read_only: false
 field_settings:
-  alternate_family_name:
-    label: 'Person Alternate Family Name'
-    datasource_id: 'entity:taxonomy_term'
-    property_path: 'field_person_alternate_names:family'
-    type: string
-    dependencies:
-      config:
-        - field.storage.taxonomy_term.field_person_alternate_names
-  alternate_given_name:
-    label: 'Person Alternate Given Name'
-    datasource_id: 'entity:taxonomy_term'
-    property_path: 'field_person_alternate_names:given'
-    type: string
-    dependencies:
-      config:
-        - field.storage.taxonomy_term.field_person_alternate_names
-  alternate_middle_name:
-    label: 'Person Alternate Middle Names'
-    datasource_id: 'entity:taxonomy_term'
-    property_path: 'field_person_alternate_names:middle'
-    type: string
-    dependencies:
-      config:
-        - field.storage.taxonomy_term.field_person_alternate_names
   author:
     label: 'Author name'
     datasource_id: 'entity:node'
@@ -304,30 +278,6 @@ field_settings:
     indexed_locked: true
     type_locked: true
     hidden: true
-  preferred_family_name:
-    label: 'Person Preferred Family Name'
-    datasource_id: 'entity:taxonomy_term'
-    property_path: 'field_person_preferred_name:family'
-    type: string
-    dependencies:
-      config:
-        - field.storage.taxonomy_term.field_person_preferred_name
-  preferred_given_name:
-    label: 'Person Preferred Given Name'
-    datasource_id: 'entity:taxonomy_term'
-    property_path: 'field_person_preferred_name:given'
-    type: string
-    dependencies:
-      config:
-        - field.storage.taxonomy_term.field_person_preferred_name
-  preferred_middle_name:
-    label: 'Person Preferred Middle Names'
-    datasource_id: 'entity:taxonomy_term'
-    property_path: 'field_person_preferred_name:middle'
-    type: string
-    dependencies:
-      config:
-        - field.storage.taxonomy_term.field_person_preferred_name
   rendered_item:
     label: 'Rendered item'
     property_path: rendered_item


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1561

Supports https://github.com/Islandora/controlled_access_terms/pull/54

# What does this Pull Request do?

Drops the person preferred and alternate name as fields in the search index since they are now only optional in controlled access terms.

# What's new?

* removes the person preferred and alternate name configs.

# How should this be tested?

* Clone a fresh playbook
* Apply the [playbook PR fixing master->main](https://github.com/Islandora-Devops/islandora-playbook/pull/189)
* Update your "[inventory/vagrant/group_vars/webserver/drupal.yml](https://github.com/Islandora-Devops/islandora-playbook/blob/dev/inventory/vagrant/group_vars/webserver/drupal.yml#L22)" so that islandora_defaults targets the issue-1561 branch: "islandora/islandora_defaults:dev-issue-1561"
* vagrant up 🚀
* When the build completes, check that the name module isn't installed.

# Additional Comments

Before we merge this PR we need to revert the change to composer.json which was changed for testing purposes.

# Interested parties
@mjordan 
