### PR TITLE
Use help text to explain linked agents.

### DIFF
--- a/config/install/field.field.node.islandora_object.field_linked_agent.yml
+++ b/config/install/field.field.node.islandora_object.field_linked_agent.yml
@@ -14,7 +14,7 @@ field_name: field_linked_agent
 entity_type: node
 bundle: islandora_object
 label: 'Linked Agent'
-description: ''
+description: 'Agents must already exist in the Person, Family, or Corporate Body taxonomy vocabularies. To create a new term, go to <em>Structure > Vocabulary</em>.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.node.islandora_object.field_linked_agent.yml
+++ b/config/install/field.field.node.islandora_object.field_linked_agent.yml
@@ -14,7 +14,7 @@ field_name: field_linked_agent
 entity_type: node
 bundle: islandora_object
 label: 'Linked Agent'
-description: 'Agents must already exist in the Person, Family, or Corporate Body taxonomy vocabularies. To create a new term, go to <em>Structure > Vocabulary</em>.'
+description: ''Agents must already exist in the Person, Family, or Corporate Body taxonomy vocabularies. To create a new term, go to <a href="/admin/structure/taxonomy" target="_blank"><em>Manage > Structure > Taxonomy</em></a>.''
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.node.islandora_object.field_linked_agent.yml
+++ b/config/install/field.field.node.islandora_object.field_linked_agent.yml
@@ -14,7 +14,7 @@ field_name: field_linked_agent
 entity_type: node
 bundle: islandora_object
 label: 'Linked Agent'
-description: 'Agents must already exist in the Person, Family, or Corporate Body taxonomy vocabularies. To create a new term, go to <a href="/admin/structure/taxonomy" target="_blank"><em>Manage > Structure > Taxonomy</em></a>.'
+description: 'Create new agents by adding terms to the <a href="/admin/structure/taxonomy/manage/person/overview">Person</a>, <a href="/admin/structure/taxonomy/manage/family/overview">Family</a>, or <a href="/admin/structure/taxonomy/manage/corporate_body/overview">Corporate Body</a> vocabularies.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.node.islandora_object.field_linked_agent.yml
+++ b/config/install/field.field.node.islandora_object.field_linked_agent.yml
@@ -14,7 +14,7 @@ field_name: field_linked_agent
 entity_type: node
 bundle: islandora_object
 label: 'Linked Agent'
-description: ''Agents must already exist in the Person, Family, or Corporate Body taxonomy vocabularies. To create a new term, go to <a href="/admin/structure/taxonomy" target="_blank"><em>Manage > Structure > Taxonomy</em></a>.''
+description: 'Agents must already exist in the Person, Family, or Corporate Body taxonomy vocabularies. To create a new term, go to <a href="/admin/structure/taxonomy" target="_blank"><em>Manage > Structure > Taxonomy</em></a>.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
**GitHub Issue**: #1685  (initial step - does not solve issue.)

Discussed at the Nov 12 User call. More help text required, but this would be a start.

# What does this Pull Request do?

Puts help text in the node form for islandora objects saying you have to put linked agents in through the taxonomy interface.

# What's new?

Description help text.

# How should this be tested?

Does it show up? Is it correct? Do the links work? Does it make sense?


# Additional Notes:
 

# Interested parties
@manez 
