### PR TITLE
remove permissions_by_term because its unused

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "islandora/openseadragon" : "dev-8.x-1.x",
     "islandora/controlled_access_terms" : "dev-8.x-1.x",
     "drupal/field_group" : "^3.0",
-    "drupal/permissions_by_term" : "^1.51",
     "drupal/field_permissions" : "^1.0"
   }
 }


### PR DESCRIPTION


# What does this Pull Request do?
Removes permissions_by_term

# What's new?
* removes composer dependency on permissions_by_term because it's not implemented in practice, allows users to choose their own permissions scheme, and it it doesn't support d8/d9 in the same version which makes life even more difficult

# How should this be tested?
Do a build and make sure you don't get permissions_by_term?

# Interested parties
@Islandora/8-x-committers @dannylamb 
