### PR TITLE
Captions

### DIFF
--- a/config/install/core.entity_form_display.media.audio.default.yml
+++ b/config/install/core.entity_form_display.media.audio.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.audio.field_captions
     - field.field.media.audio.field_file_size
     - field.field.media.audio.field_media_audio_file
     - field.field.media.audio.field_media_of
@@ -19,9 +20,16 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_captions:
+    type: file_generic
+    weight: 10
+    region: content
+    settings:
+      progress_indicator: throbber
     third_party_settings: {  }
   field_media_audio_file:
     weight: 1
@@ -32,12 +40,13 @@ content:
     region: content
   field_media_of:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
+      match_limit: 10
     third_party_settings: {  }
   field_media_use:
     type: options_buttons
@@ -46,7 +55,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_original_name:
-    weight: 26
+    weight: 9
     settings:
       rows: 5
       placeholder: ''
@@ -63,7 +72,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -71,21 +80,22 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 7
     region: content
     third_party_settings: {  }
   translation:
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
+      match_limit: 10
     region: content
     third_party_settings: {  }
 hidden:

--- a/config/install/core.entity_form_display.media.video.default.yml
+++ b/config/install/core.entity_form_display.media.video.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.video.field_captions
     - field.field.media.video.field_file_size
     - field.field.media.video.field_media_of
     - field.field.media.video.field_media_use
@@ -19,18 +20,26 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_captions:
+    type: file_generic
+    weight: 10
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
   field_media_of:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
+      match_limit: 10
     third_party_settings: {  }
   field_media_use:
     type: options_buttons
@@ -46,7 +55,7 @@ content:
     type: file_generic
     region: content
   field_original_name:
-    weight: 26
+    weight: 9
     settings:
       rows: 5
       placeholder: ''
@@ -63,7 +72,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -71,21 +80,22 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 7
     region: content
     third_party_settings: {  }
   translation:
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
+      match_limit: 10
     region: content
     third_party_settings: {  }
 hidden:

--- a/config/install/core.entity_view_display.media.audio.default.yml
+++ b/config/install/core.entity_view_display.media.audio.default.yml
@@ -1,4 +1,3 @@
-uuid: 8626be18-5f43-493e-a2f9-8f8616b1aca9
 langcode: en
 status: true
 dependencies:

--- a/config/install/core.entity_view_display.media.audio.default.yml
+++ b/config/install/core.entity_view_display.media.audio.default.yml
@@ -1,7 +1,9 @@
+uuid: 8626be18-5f43-493e-a2f9-8f8616b1aca9
 langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.audio.field_captions
     - field.field.media.audio.field_file_size
     - field.field.media.audio.field_media_audio_file
     - field.field.media.audio.field_media_of
@@ -10,7 +12,7 @@ dependencies:
     - field.field.media.audio.field_original_name
     - media.type.audio
   module:
-    - file
+    - islandora_defaults
 id: media.audio.default
 targetEntityType: media
 bundle: audio
@@ -27,11 +29,11 @@ content:
     third_party_settings: {  }
   field_gemini_uri:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_audio_file:
-    type: file_audio
+    type: file_audio_caption
     weight: 1
     label: visually_hidden
     settings:
@@ -82,6 +84,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_captions: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/config/install/core.entity_view_display.media.audio.source.yml
+++ b/config/install/core.entity_view_display.media.audio.source.yml
@@ -1,4 +1,3 @@
-uuid: e5d47fba-0331-465f-8563-84536d5819e1
 langcode: en
 status: true
 dependencies:

--- a/config/install/core.entity_view_display.media.audio.source.yml
+++ b/config/install/core.entity_view_display.media.audio.source.yml
@@ -1,8 +1,10 @@
+uuid: e5d47fba-0331-465f-8563-84536d5819e1
 langcode: en
 status: true
 dependencies:
   config:
     - core.entity_view_mode.media.source
+    - field.field.media.audio.field_captions
     - field.field.media.audio.field_file_size
     - field.field.media.audio.field_media_audio_file
     - field.field.media.audio.field_media_of
@@ -14,7 +16,7 @@ dependencies:
     module:
       - islandora_core_feature
   module:
-    - file
+    - islandora_defaults
 id: media.audio.source
 targetEntityType: media
 bundle: audio
@@ -22,11 +24,11 @@ mode: source
 content:
   field_gemini_uri:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_audio_file:
-    type: file_audio
+    type: file_audio_caption
     weight: 0
     label: visually_hidden
     settings:
@@ -38,6 +40,7 @@ content:
     region: content
 hidden:
   created: true
+  field_captions: true
   field_file_size: true
   field_media_of: true
   field_media_use: true

--- a/config/install/core.entity_view_display.media.video.default.yml
+++ b/config/install/core.entity_view_display.media.video.default.yml
@@ -1,7 +1,9 @@
+uuid: c87e7dfc-c264-43ee-affd-077a175173bb
 langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.video.field_captions
     - field.field.media.video.field_file_size
     - field.field.media.video.field_media_of
     - field.field.media.video.field_media_use
@@ -10,7 +12,7 @@ dependencies:
     - field.field.media.video.field_original_name
     - media.type.video
   module:
-    - file
+    - islandora_defaults
 id: media.video.default
 targetEntityType: media
 bundle: video
@@ -27,9 +29,9 @@ content:
     third_party_settings: {  }
   field_gemini_uri:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_of:
     type: entity_reference_label
     weight: 4
@@ -47,7 +49,7 @@ content:
       link: true
     third_party_settings: {  }
   field_media_video_file:
-    type: file_video
+    type: file_video_caption
     weight: 1
     label: visually_hidden
     settings:
@@ -85,6 +87,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_captions: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/config/install/core.entity_view_display.media.video.default.yml
+++ b/config/install/core.entity_view_display.media.video.default.yml
@@ -1,4 +1,3 @@
-uuid: c87e7dfc-c264-43ee-affd-077a175173bb
 langcode: en
 status: true
 dependencies:

--- a/config/install/core.entity_view_display.media.video.source.yml
+++ b/config/install/core.entity_view_display.media.video.source.yml
@@ -1,4 +1,3 @@
-uuid: 41a1c97b-5283-493a-8d93-8d8653698e41
 langcode: en
 status: true
 dependencies:

--- a/config/install/core.entity_view_display.media.video.source.yml
+++ b/config/install/core.entity_view_display.media.video.source.yml
@@ -1,8 +1,10 @@
+uuid: 41a1c97b-5283-493a-8d93-8d8653698e41
 langcode: en
 status: true
 dependencies:
   config:
     - core.entity_view_mode.media.source
+    - field.field.media.video.field_captions
     - field.field.media.video.field_file_size
     - field.field.media.video.field_media_of
     - field.field.media.video.field_media_use
@@ -14,7 +16,7 @@ dependencies:
     module:
       - islandora_core_feature
   module:
-    - file
+    - islandora_defaults
 id: media.video.source
 targetEntityType: media
 bundle: video
@@ -22,11 +24,11 @@ mode: source
 content:
   field_gemini_uri:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_video_file:
-    type: file_video
+    type: file_video_caption
     weight: 0
     label: visually_hidden
     settings:
@@ -41,6 +43,7 @@ content:
     region: content
 hidden:
   created: true
+  field_captions: true
   field_file_size: true
   field_media_of: true
   field_media_use: true

--- a/config/install/field.field.media.audio.field_captions.yml
+++ b/config/install/field.field.media.audio.field_captions.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_captions
+    - media.type.audio
+  module:
+    - file
+id: media.audio.field_captions
+field_name: field_captions
+entity_type: media
+bundle: audio
+label: Captions
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'vtt'
+  max_filesize: ''
+  description_field: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/config/install/field.field.media.video.field_captions.yml
+++ b/config/install/field.field.media.video.field_captions.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_captions
+    - media.type.video
+  module:
+    - file
+id: media.video.field_captions
+field_name: field_captions
+entity_type: media
+bundle: video
+label: Captions
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'vtt'
+  max_filesize: ''
+  description_field: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/config/install/field.storage.media.field_captions.yml
+++ b/config/install/field.storage.media.field_captions.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - file
+    - media
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: media.field_captions
+field_name: field_captions
+entity_type: media
+type: file
+settings:
+  display_field: false
+  display_default: false
+  uri_scheme: fedora
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/islandora_defaults.module
+++ b/islandora_defaults.module
@@ -25,16 +25,16 @@ function islandora_defaults_theme() {
         'caption' => NULL,
         'files' => [],
         'poster' => NULL,
-        'attributes' => NULL
-      ]
+        'attributes' => NULL,
+      ],
     ],
     'file_audio_with_caption' => [
       'template' => 'file-audio-caption',
       'variables' => [
         'caption' => NULL,
         'files' => [],
-        'attributes' => NULL
-      ]
+        'attributes' => NULL,
+      ],
     ],
   ];
 }

--- a/islandora_defaults.module
+++ b/islandora_defaults.module
@@ -13,3 +13,28 @@ function islandora_defaults_rdf_namespaces() {
     'relators' => 'http://id.loc.gov/vocabulary/relators/',
   ];
 }
+
+/**
+ * Implements hook_theme().
+ */
+function islandora_defaults_theme() {
+  return [
+    'file_video_with_caption' => [
+      'template' => 'file-video-caption',
+      'variables' => [
+        'caption' => NULL,
+        'files' => [],
+        'poster' => NULL,
+        'attributes' => NULL
+      ]
+    ],
+    'file_audio_with_caption' => [
+      'template' => 'file-audio-caption',
+      'variables' => [
+        'caption' => NULL,
+        'files' => [],
+        'attributes' => NULL
+      ]
+    ],
+  ];
+}

--- a/src/Plugin/Field/FieldFormatter/FileAudioCaptionFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FileAudioCaptionFormatter.php
@@ -1,4 +1,4 @@
-<?php
+?<?php
 
 namespace Drupal\islandora_defaults\Plugin\Field\FieldFormatter;
 
@@ -32,7 +32,6 @@ class FileAudioCaptionFormatter extends FileAudioFormatter {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
-    $utils = \Drupal::service('islandora.utils');
 
     $source_files = $this->getSourceFiles($items, $langcode);
     if (empty($source_files)) {
@@ -47,7 +46,6 @@ class FileAudioCaptionFormatter extends FileAudioFormatter {
       if ($first_media->get('field_captions')->entity != NULL) {
         $caption = $first_media->get('field_captions')->entity->createFileUrl();
       }
-      $node = $utils->getParentNode($first_media);
 
       $elements[$delta] = [
         '#theme' => 'file_audio_with_caption',

--- a/src/Plugin/Field/FieldFormatter/FileAudioCaptionFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FileAudioCaptionFormatter.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\islandora_defaults\Plugin\Field\FieldFormatter;
+
+use Drupal\file\Plugin\Field\FieldFormatter\FileAudioFormatter;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Cache\Cache;
+
+/**
+ * Plugin implementation of the 'file_audio_caption' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "file_audio_caption",
+ *   label = @Translation("audio with Caption"),
+ *   description = @Translation("Display the file using an HTML5 audio tag and caption track."),
+ *   field_types = {
+ *     "file"
+ *   }
+ * )
+ */
+class FileAudioCaptionFormatter extends FileAudioFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getMediaType() {
+    return 'audio';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $utils = \Drupal::service('islandora.utils');
+
+    $source_files = $this->getSourceFiles($items, $langcode);
+    if (empty($source_files)) {
+      return $elements;
+    }
+
+    $attributes = $this->prepareAttributes();
+    foreach ($source_files as $delta => $files) {
+      $file = $files[0]['file'];
+      $medias = \Drupal::service('islandora.utils')->getReferencingMedia($file->id());
+      $first_media = array_values($medias)[0];
+      if ($first_media->get('field_captions')->entity != NULL) {
+        $caption = $first_media->get('field_captions')->entity->createFileUrl();
+      }
+      $node = $utils->getParentNode($first_media);
+
+      $elements[$delta] = [
+        '#theme' => 'file_audio_with_caption',
+        '#attributes' => $attributes,
+        '#files' => $files,
+        '#cache' => ['tags' => []],
+      ];
+
+      if (isset($caption)) {
+        $elements[$delta]['#caption'] = $caption;
+      }
+
+      $cache_tags = [];
+      foreach ($files as $file) {
+        $cache_tags = Cache::mergeTags($cache_tags, $file['file']->getCacheTags());
+      }
+      $elements[$delta]['#cache']['tags'] = $cache_tags;
+    }
+    return $elements;
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/FileAudioCaptionFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FileAudioCaptionFormatter.php
@@ -1,4 +1,4 @@
-?<?php
+<?php
 
 namespace Drupal\islandora_defaults\Plugin\Field\FieldFormatter;
 

--- a/src/Plugin/Field/FieldFormatter/FileVideoCaptionFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FileVideoCaptionFormatter.php
@@ -3,9 +3,11 @@
 namespace Drupal\islandora_defaults\Plugin\Field\FieldFormatter;
 
 use Drupal\file\Plugin\Field\FieldFormatter\FileVideoFormatter;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\islandora\IslandoraUtils;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the 'file_video_caption' formatter.
@@ -78,13 +80,7 @@ class FileVideoCaptionFormatter extends FileVideoFormatter {
    *   Islandora utils.
    */
   public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, IslandoraUtils $utils) {
-    parent::__construct([], $plugin_id, $plugin_definition);
-
-    $this->fieldDefinition = $field_definition;
-    $this->settings = $settings;
-    $this->label = $label;
-    $this->viewMode = $view_mode;
-    $this->thirdPartySettings = $third_party_settings;
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
     $this->utils = $utils;
   }
 

--- a/src/Plugin/Field/FieldFormatter/FileVideoCaptionFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FileVideoCaptionFormatter.php
@@ -5,6 +5,7 @@ namespace Drupal\islandora_defaults\Plugin\Field\FieldFormatter;
 use Drupal\file\Plugin\Field\FieldFormatter\FileVideoFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Cache\Cache;
+use Drupal\islandora\IslandoraUtils;
 
 /**
  * Plugin implementation of the 'file_video_caption' formatter.
@@ -20,6 +21,80 @@ use Drupal\Core\Cache\Cache;
  */
 class FileVideoCaptionFormatter extends FileVideoFormatter {
 
+
+  /**
+   * The field definition.
+   *
+   * @var \Drupal\Core\Field\FieldDefinitionInterface
+   */
+  protected $fieldDefinition;
+
+  /**
+   * The formatter settings.
+   *
+   * @var array
+   */
+  protected $settings;
+
+  /**
+   * The label display setting.
+   *
+   * @var string
+   */
+  protected $label;
+
+  /**
+   * The view mode.
+   *
+   * @var string
+   */
+  protected $viewMode;
+
+  /**
+   * Islandora utility functions.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
+
+  /**
+   * Constructs a FormatterBase object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\islandora\IslandoraUtils $utils
+   *   Islandora utils.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, IslandoraUtils $utils) {
+    parent::__construct([], $plugin_id, $plugin_definition);
+
+    $this->fieldDefinition = $field_definition;
+    $this->settings = $settings;
+    $this->label = $label;
+    $this->viewMode = $view_mode;
+    $this->thirdPartySettings = $third_party_settings;
+    $this->utils = $utils;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static($plugin_id, $plugin_definition, $configuration['field_definition'], $configuration['settings'], $configuration['label'], $configuration['view_mode'], $configuration['third_party_settings'], $container->get('islandora.utils'));
+  }
+
   /**
    * {@inheritdoc}
    */
@@ -32,7 +107,6 @@ class FileVideoCaptionFormatter extends FileVideoFormatter {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
-    $utils = \Drupal::service('islandora.utils');
 
     $source_files = $this->getSourceFiles($items, $langcode);
     if (empty($source_files)) {
@@ -47,9 +121,9 @@ class FileVideoCaptionFormatter extends FileVideoFormatter {
       if ($first_media->get('field_captions')->entity != NULL) {
         $caption = $first_media->get('field_captions')->entity->createFileUrl();
       }
-      $node = $utils->getParentNode($first_media);
-      $thumbn_term = $utils->getTermForUri('http://pcdm.org/use#ThumbnailImage');
-      $thumb_media = $utils->getMediaWithTerm($node, $thumbn_term);
+      $node = $this->utils->getParentNode($first_media);
+      $thumbn_term = $this->utils->getTermForUri('http://pcdm.org/use#ThumbnailImage');
+      $thumb_media = $this->utils->getMediaWithTerm($node, $thumbn_term);
       if ($thumb_media) {
         $poster = $thumb_media->get('field_media_image')->entity->createFileUrl();
       }

--- a/src/Plugin/Field/FieldFormatter/FileVideoCaptionFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FileVideoCaptionFormatter.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\islandora_defaults\Plugin\Field\FieldFormatter;
+
+use Drupal\file\Plugin\Field\FieldFormatter\FileVideoFormatter;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Cache\Cache;
+
+/**
+ * Plugin implementation of the 'file_video_caption' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "file_video_caption",
+ *   label = @Translation("Video with Caption"),
+ *   description = @Translation("Display the file using an HTML5 video tag and caption track."),
+ *   field_types = {
+ *     "file"
+ *   }
+ * )
+ */
+class FileVideoCaptionFormatter extends FileVideoFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getMediaType() {
+    return 'video';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $utils = \Drupal::service('islandora.utils');
+
+    $source_files = $this->getSourceFiles($items, $langcode);
+    if (empty($source_files)) {
+      return $elements;
+    }
+
+    $attributes = $this->prepareAttributes();
+    foreach ($source_files as $delta => $files) {
+      $file = $files[0]['file'];
+      $medias = \Drupal::service('islandora.utils')->getReferencingMedia($file->id());
+      $first_media = array_values($medias)[0];
+      if ($first_media->get('field_captions')->entity != NULL) {
+        $caption = $first_media->get('field_captions')->entity->createFileUrl();
+      }
+      $node = $utils->getParentNode($first_media);
+      $thumbn_term = $utils->getTermForUri('http://pcdm.org/use#ThumbnailImage');
+      $thumb_media = $utils->getMediaWithTerm($node, $thumbn_term);
+      if ($thumb_media) {
+        $poster = $thumb_media->get('field_media_image')->entity->createFileUrl();
+      }
+
+      $elements[$delta] = [
+        '#theme' => 'file_video_with_caption',
+        '#attributes' => $attributes,
+        '#files' => $files,
+        '#cache' => ['tags' => []],
+      ];
+
+      if (isset($caption)) {
+        $elements[$delta]['#caption'] = $caption;
+      }
+      if (isset($poster)) {
+        $elements[$delta]['#poster'] = $poster;
+      }
+
+      $cache_tags = [];
+      foreach ($files as $file) {
+        $cache_tags = Cache::mergeTags($cache_tags, $file['file']->getCacheTags());
+      }
+      $elements[$delta]['#cache']['tags'] = $cache_tags;
+    }
+    return $elements;
+  }
+
+}

--- a/templates/file-audio-caption.html.twig
+++ b/templates/file-audio-caption.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+* @file
+* Default theme implementation to display the file entity as a audio tag.
+*
+* Available variables:
+* - attributes: An array of HTML attributes, intended to be added to the
+*   audio tag.
+* - files: And array of files to be added as sources for the audio tag. Each
+*   element is an array with the following elements:
+*   - file: The full file object.
+*   - source_attributes: An array of HTML attributes for to be added to the
+*     source tag.
+* - caption: the captions file
+*
+* @ingroup themeable
+*/
+#}
+<audio controls="controls" width="100%" crossorigin="anonymous">
+  {% for file in files %}
+    <source {{ file.source_attributes }} />
+  {% endfor %}
+  {% if caption %}
+    <track src="{{ caption }}" kind="captions" crossorigin="anonymous">
+  {% endif %}
+Your browser does not support the audio tag.
+</audio>

--- a/templates/file-video-caption.html.twig
+++ b/templates/file-video-caption.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+* @file
+* Default theme implementation to display the file entity as a video tag.
+*
+* Available variables:
+* - attributes: An array of HTML attributes, intended to be added to the
+*   video tag.
+* - files: And array of files to be added as sources for the video tag. Each
+*   element is an array with the following elements:
+*   - file: The full file object.
+*   - source_attributes: An array of HTML attributes for to be added to the
+*     source tag.
+* - caption: the captions file
+* - poster: the poster (thumbnail) file
+*
+* @ingroup themeable
+*/
+#}
+{% if poster %}
+  <video controls="controls" width="100%" poster="{{ poster }}" crossorigin="anonymous">
+{% else %}
+  <video controls="controls" width="100%" crossorigin="anonymous">
+{% endif %}
+  {% for file in files %}
+    <source {{ file.source_attributes }} />
+  {% endfor %}
+  {% if caption %}
+    <track src="{{ caption }}" kind="captions" crossorigin="anonymous">
+  {% endif %}
+Your browser does not support the video tag.
+</video>


### PR DESCRIPTION
**GitHub Issue**: 
https://github.com/Islandora/documentation/issues/1305
https://github.com/Islandora/documentation/issues/1003
https://www.drupal.org/project/drupal/issues/3057144
https://www.drupal.org/project/drupal/issues/3056714

* Other Relevant Links 
 Perhaps superseding https://github.com/Islandora/islandora/pull/743/files

# What does this Pull Request do?
Adds a caption field for audio and video files and allows them to played in the HTML5 player

# What's new?
* adds a caption file field for VTT files to the audio and video media types
* displays that caption field on the form for audio and video
* adds field formatters for the audio and video file fields that pulls in the captions file if it exists
* changes the view modes for audio and video to use the new field formatter by default
* adds templates for the HTML5 player with captions
* allows adding the thumbnail for a video as the "poster" in the player


# How should this be tested?
* spin up an islandora site
* pull in this islandora_defaults PR
* do a partial config import on the config/install directory of islandora_defaults
* cache clear
* add an audio and/or video node
* add an audio and/or video original file media attached to that node
* when the service file derivative is created, add a VTT caption file to that service file media in the new captions field
* view the node - in the menu on the HTML5 player, you should be able to toggle on and off captions
* if it was a video and it got a thumbnail derivative - it should display as the "poster" before playing the video in the player

For testing I used the following video and captions: https://github.com/iandevlin/iandevlin.github.io/blob/master/mdn/video-player-with-captions/video/sintel-short.mp4 and https://github.com/iandevlin/iandevlin.github.io/blob/master/mdn/video-player-with-captions/subtitles/vtt/sintel-en.vtt

# Additional Notes:
* should the captions should live on the original file or the service file? - ultimately it depends on which you're displaying to the user. islandora_defaults ships with the service file being displayed so that's why my instructions say to add it there
* is this where this stuff should go? or should it be part of islandora_audio and islandora_video in islandora/islandora? or split up somehow into FieldFormatters there and config here?


# Interested parties
@Islandora/8-x-committers
@Natkeeran 
