### PR TITLE
Change descriptions of overwritten media types.

### DIFF
--- a/config/install/media.type.audio.yml
+++ b/config/install/media.type.audio.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: audio
 label: Audio
-description: 'A locally hosted audio file.'
+description: 'An audio file, stored in Fedora.'
 source: audio_file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.audio.yml
+++ b/config/install/media.type.audio.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: audio
 label: Audio
-description: 'An audio file, stored in Fedora.'
+description: 'An audio file.'
 source: audio_file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.document.yml
+++ b/config/install/media.type.document.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: document
 label: Document
-description: 'PDF and other document files, stored in Fedora.'
+description: 'PDF and other document files.'
 source: file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.document.yml
+++ b/config/install/media.type.document.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: document
 label: Document
-description: 'An uploaded file or document, such as a PDF.'
+description: 'A file or document, such as a PDF, stored in Fedora.'
 source: file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.document.yml
+++ b/config/install/media.type.document.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: document
 label: Document
-description: 'A file or document, such as a PDF, stored in Fedora.'
+description: 'PDF and other document files, stored in Fedora.'
 source: file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.file.yml
+++ b/config/install/media.type.file.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: file
 label: File
-description: 'Files that do not fit into other types listed here, stored in Fedora. Also use for TIFFs and JP2s.'
+description: 'Files that do not fit into other types listed here. Also use for TIFFs and JP2s.'
 source: file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.file.yml
+++ b/config/install/media.type.file.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: file
 label: File
-description: 'Use local files for reusable media.'
+description: 'A binary file, stored in Fedora.'
 source: file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.file.yml
+++ b/config/install/media.type.file.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: file
 label: File
-description: 'A binary file, stored in Fedora.'
+description: 'Files that do not fit into other types listed here, stored in Fedora. Also use for TIFFs and JP2s.'
 source: file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.image.yml
+++ b/config/install/media.type.image.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: image
 label: Image
-description: 'An image file (other than TIFF and JP2 formats), stored in Fedora. Use "File" for TIFF or JP2 files.'
+description: 'An image file (other than TIFF and JP2 formats). Use "File" for TIFF or JP2 files.'
 source: image
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.image.yml
+++ b/config/install/media.type.image.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: image
 label: Image
-description: 'Use local images for reusable media.'
+description: 'An image file, stored in Fedora.'
 source: image
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.image.yml
+++ b/config/install/media.type.image.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: image
 label: Image
-description: 'An image file, stored in Fedora.'
+description: 'An image file (other than TIFF and JP2 formats), stored in Fedora. Use "File" for TIFF or JP2 files.'
 source: image
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.video.yml
+++ b/config/install/media.type.video.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: video
 label: Video
-description: 'A video file, stored in Fedora.'
+description: 'A video file.'
 source: video_file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/install/media.type.video.yml
+++ b/config/install/media.type.video.yml
@@ -6,7 +6,7 @@ dependencies:
       - islandora_core_feature
 id: video
 label: Video
-description: 'A locally hosted video file.'
+description: 'A video file, stored in Fedora.'
 source: video_file
 queue_thumbnail_downloads: false
 new_revision: true


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1541 

Other Relevant Links: 

* https://github.com/Islandora/documentation/pull/1721/files/dc48110df6aa703f2173d84b90682e92c94e41f6#r556551620
 

# What does this Pull Request do?

Changes the descriptions of the media types

# What's new?

* Changes descriptions to avoid implying that these media are for "local" files.
* Clarifies that TIFFs and JP2s should be in File, not Image media.
* Claims that these media have files "stored in Fedora". (since this is Defaults so this is true, for files added through the GUI.)

# How should this be tested?

Re-install this feature per @mjordan 's directions, here: https://github.com/Islandora/documentation/issues/1541#issuecomment-662665757

Does the "Add media" page reflect the new text?

# Additional Notes:


# Interested parties

@dannylamb @manez 