### PR TITLE
captions v2

### DIFF
--- a/config/install/core.entity_form_display.media.audio.default.yml
+++ b/config/install/core.entity_form_display.media.audio.default.yml
@@ -8,9 +8,11 @@ dependencies:
     - field.field.media.audio.field_media_use
     - field.field.media.audio.field_mime_type
     - field.field.media.audio.field_original_name
+    - field.field.media.audio.field_track
     - media.type.audio
   module:
     - file
+    - islandora
     - path
 id: media.audio.default
 targetEntityType: media
@@ -52,6 +54,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
+    region: content
+  field_track:
+    weight: 27
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: media_track
     region: content
   name:
     type: string_textfield

--- a/config/install/core.entity_form_display.media.video.default.yml
+++ b/config/install/core.entity_form_display.media.video.default.yml
@@ -8,9 +8,11 @@ dependencies:
     - field.field.media.video.field_media_video_file
     - field.field.media.video.field_mime_type
     - field.field.media.video.field_original_name
+    - field.field.media.video.field_track
     - media.type.video
   module:
     - file
+    - islandora
     - path
 id: media.video.default
 targetEntityType: media
@@ -52,6 +54,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
+    region: content
+  field_track:
+    weight: 27
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: media_track
     region: content
   name:
     type: string_textfield

--- a/config/install/core.entity_view_display.media.audio.default.yml
+++ b/config/install/core.entity_view_display.media.audio.default.yml
@@ -8,9 +8,10 @@ dependencies:
     - field.field.media.audio.field_media_use
     - field.field.media.audio.field_mime_type
     - field.field.media.audio.field_original_name
+    - field.field.media.audio.field_track
     - media.type.audio
   module:
-    - file
+    - islandora_audio
 id: media.audio.default
 targetEntityType: media
 bundle: audio
@@ -27,11 +28,11 @@ content:
     third_party_settings: {  }
   field_gemini_uri:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_audio_file:
-    type: file_audio
+    type: islandora_file_audio
     weight: 1
     label: visually_hidden
     settings:
@@ -82,6 +83,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_track: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/config/install/core.entity_view_display.media.audio.source.yml
+++ b/config/install/core.entity_view_display.media.audio.source.yml
@@ -9,12 +9,13 @@ dependencies:
     - field.field.media.audio.field_media_use
     - field.field.media.audio.field_mime_type
     - field.field.media.audio.field_original_name
+    - field.field.media.audio.field_track
     - media.type.audio
   enforced:
     module:
       - islandora_core_feature
   module:
-    - file
+    - islandora_audio
 id: media.audio.source
 targetEntityType: media
 bundle: audio
@@ -22,11 +23,11 @@ mode: source
 content:
   field_gemini_uri:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_audio_file:
-    type: file_audio
+    type: islandora_file_audio
     weight: 0
     label: visually_hidden
     settings:
@@ -43,6 +44,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_track: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/config/install/core.entity_view_display.media.video.default.yml
+++ b/config/install/core.entity_view_display.media.video.default.yml
@@ -8,9 +8,10 @@ dependencies:
     - field.field.media.video.field_media_video_file
     - field.field.media.video.field_mime_type
     - field.field.media.video.field_original_name
+    - field.field.media.video.field_track
     - media.type.video
   module:
-    - file
+    - islandora_video
 id: media.video.default
 targetEntityType: media
 bundle: video
@@ -27,9 +28,9 @@ content:
     third_party_settings: {  }
   field_gemini_uri:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_of:
     type: entity_reference_label
     weight: 4
@@ -47,7 +48,7 @@ content:
       link: true
     third_party_settings: {  }
   field_media_video_file:
-    type: file_video
+    type: islandora_file_video
     weight: 1
     label: visually_hidden
     settings:
@@ -85,6 +86,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_track: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/config/install/core.entity_view_display.media.video.source.yml
+++ b/config/install/core.entity_view_display.media.video.source.yml
@@ -9,12 +9,13 @@ dependencies:
     - field.field.media.video.field_media_video_file
     - field.field.media.video.field_mime_type
     - field.field.media.video.field_original_name
+    - field.field.media.video.field_track
     - media.type.video
   enforced:
     module:
       - islandora_core_feature
   module:
-    - file
+    - islandora_video
 id: media.video.source
 targetEntityType: media
 bundle: video
@@ -22,11 +23,11 @@ mode: source
 content:
   field_gemini_uri:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_video_file:
-    type: file_video
+    type: islandora_file_video
     weight: 0
     label: visually_hidden
     settings:
@@ -46,6 +47,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_track: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/config/install/field.field.media.audio.field_track.yml
+++ b/config/install/field.field.media.audio.field_track.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_track
+    - media.type.audio
+  module:
+    - content_translation
+    - islandora
+third_party_settings:
+  content_translation:
+    translation_sync:
+      file: '0'
+      label: '0'
+      kind: '0'
+      srclang: '0'
+      default: '0'
+id: media.audio.field_track
+field_name: field_track
+entity_type: media
+bundle: audio
+label: Track
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: vtt
+  max_filesize: ''
+  languages: installed
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: media_track

--- a/config/install/field.field.media.video.field_track.yml
+++ b/config/install/field.field.media.video.field_track.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_track
+    - media.type.video
+  module:
+    - islandora
+id: media.video.field_track
+field_name: field_track
+entity_type: media
+bundle: video
+label: Track
+description: 'Supply a caption file here.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: vtt
+  max_filesize: ''
+  languages: installed
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: media_track

--- a/config/install/field.storage.media.field_track.yml
+++ b/config/install/field.storage.media.field_track.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - file
+    - islandora
+    - media
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: media.field_track
+field_name: field_track
+entity_type: media
+type: media_track
+settings:
+  uri_scheme: fedora
+  target_type: file
+  display_field: false
+  display_default: false
+module: islandora
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
GitHub Issue:
Islandora/documentation#1305
Islandora/documentation#1003
https://www.drupal.org/project/drupal/issues/3057144
https://www.drupal.org/project/drupal/issues/3056714

Other Relevant Links
Perhaps superseding https://github.com/Islandora/islandora/pull/743/files
Definitely supersedes https://github.com/Islandora/islandora_defaults/pull/44

# What does this Pull Request do?
Takes the work in the patch 16 here https://www.drupal.org/project/drupal/issues/3056714  
Allows a user to add a "track" to an audio or video media object which will play in the HTML5 player

# What's new?
* config related to the code in the islandora PR https://github.com/Islandora/islandora/pull/826

# How should this be tested?
* spin up an islandora site
* pull in this islandora_defaults PR and the islandora PR https://github.com/Islandora/islandora/pull/826
* do a partial config import on the config/install directory of islandora_defaults
* cache clear
* add an audio and/or video node
* add an audio and/or video original file media attached to that node
* when the service file derivative is created, add a VTT caption file to that service file media in the new track field
* view the node - in the menu on the HTML5 player, you should be able to toggle on and off captions

# Additional Notes
* this does not have the poster/thumbnail feature i presented in https://github.com/Islandora/islandora_defaults/pull/44

# Interested parties
@Islandora/8-x-committers @Natkeeran 
