### PR TITLE
add pdf module dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "islandora/openseadragon" : "dev-8.x-1.x",
     "islandora/controlled_access_terms" : "dev-8.x-1.x",
     "drupal/field_group" : "^3.0",
-    "drupal/field_permissions" : "^1.0"
+    "drupal/field_permissions" : "^1.0",
+    "drupal/pdf": "^1.1"
   }
 }


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?

Adds the PDF module as a dependency in composer.json.

# How should this be tested?

* Spin up and ISLE using `make local` (get https://github.com/Islandora-Devops/isle-dc/pull/156 first)
* in your codebase `composer require islandora/islandora_defaults:dev-8.x-1.x`
* Attempt to enable islandora_defaults and receive the following response:
```
In PmCommands.php line 265:
                                                                                                
  Unable to install modules: module 'islandora_defaults' is missing its dependency module pdf.  
```
* in your codebase `composer require drupal/pdf`
* Enable islandora_defaults again and receive no errors

I realize, of course, that this doesn't *directly* test the PR, but I wasn't sure how to get composer to check the PR's version of composer for dependencies.... I won't complain if someone can come up with better instructions.

# Interested parties
@Islandora/8-x-committers