### PR TITLE
Add taxonomy manager as required module for OOTB experience.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "islandora/controlled_access_terms" : "dev-8.x-1.x",
     "drupal/field_group" : "^3.0",
     "drupal/field_permissions" : "^1.0",
-    "drupal/pdf": "^1.1"
+    "drupal/pdf": "^1.1",
+    "drupal/taxonomy_manager": "^2.0"
   }
 }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/islandora-starter-site/issues/37

* Other Relevant Links: Discussed in [MIG Meeting](https://github.com/islandora-interest-groups/Islandora-Metadata-Interest-Group/blob/main/Meetings/2021/2021-09-27.md)


# What does this Pull Request do?

Adds a new module to be installed with Defaults.  This enables some desired features for taxonomy management (though is sadly lacking, it's better than nothing).

# What's new?

Require taxonomy_manager.

* Does this change require documentation to be updated?  Yes - incoming PR.
* Does this change add any new dependencies? Yes - taxonomy manager.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

Install via the Playbook or Isle, and you should get a Drupal with Taxonomy manager installed.

# Additional Notes:

This seems odd here but there currently isn't a single place to add this so that Ansible and ISLE will both load it.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
