### PR TITLE
change abstract from string to text

### DIFF
--- a/config/install/core.entity_form_display.node.islandora_object.default.yml
+++ b/config/install/core.entity_form_display.node.islandora_object.default.yml
@@ -267,7 +267,7 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: string_textarea
+    type: text_textarea
     region: content
   field_alt_title:
     weight: 9

--- a/config/install/core.entity_view_display.node.islandora_object.binary.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.binary.yml
@@ -71,6 +71,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_abstract:
+    weight: 19
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
   field_classification:
     type: string
     weight: 28
@@ -327,7 +334,6 @@ hidden:
   display_media_entity_view_1: true
   display_media_service_file: true
   display_media_thumbnail: true
-  field_abstract: true
   field_alt_title: true
   field_copyright_date: true
   field_date_captured: true

--- a/config/install/core.entity_view_display.node.islandora_object.default.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.default.yml
@@ -70,7 +70,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: basic_string
+    type: text_default
     region: content
   field_alt_title:
     weight: 4

--- a/config/install/core.entity_view_display.node.islandora_object.open_seadragon.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.open_seadragon.yml
@@ -68,6 +68,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_abstract:
+    weight: 19
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
   field_classification:
     type: string
     weight: 28
@@ -330,7 +337,6 @@ hidden:
   display_media_entity_view_2: true
   display_media_service_file: true
   display_media_thumbnail: true
-  field_abstract: true
   field_alt_title: true
   field_copyright_date: true
   field_date_captured: true

--- a/config/install/core.entity_view_display.node.islandora_object.pdfjs.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.pdfjs.yml
@@ -61,6 +61,13 @@ targetEntityType: node
 bundle: islandora_object
 mode: pdfjs
 content:
+  field_abstract:
+    weight: 19
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
   field_classification:
     type: string
     weight: 28
@@ -323,7 +330,6 @@ hidden:
   display_media_entity_view_2: true
   display_media_service_file: true
   display_media_thumbnail: true
-  field_abstract: true
   field_alt_title: true
   field_copyright_date: true
   field_date_captured: true

--- a/config/install/field.field.node.islandora_object.field_abstract.yml
+++ b/config/install/field.field.node.islandora_object.field_abstract.yml
@@ -15,4 +15,4 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string_long
+field_type: text_long

--- a/config/install/field.storage.node.field_abstract.yml
+++ b/config/install/field.storage.node.field_abstract.yml
@@ -2,15 +2,11 @@ langcode: en
 status: true
 dependencies:
   module:
-    - field_permissions
     - node
-third_party_settings:
-  field_permissions:
-    permission_type: public
 id: node.field_abstract
 field_name: field_abstract
 entity_type: node
-type: string_long
+type: text_long
 settings:
   case_sensitive: false
 module: core


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1977

See [the conversation on Slack](https://islandora.slack.com/archives/CM9CVQWJ0/p1633977720028300).

# What does this Pull Request do?

Changes the abstract field from string to text to allow formatting, such as italics.

As a bonus, adds abstract to the other node display modes since it was only in default and not in binary, pdfjs, or openseadragon.

# What's new?

* Changes the abstract field from string to text and updates the related form and view displays.
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? This is for new installs.
* Could this change impact execution of existing code? No.

# How should this be tested?

* Spin up an islandora_defaults, the abstract field won't allow formatting.
* Spin up a new islandora_defaults with the PR, the abstract field does support formatting.

# Interested parties
@Islandora/8-x-committers, esp @rosiel.
