### PR TITLE
removes references to field_alternative_title, replacing with alt_title where necessary

### DIFF
--- a/config/install/core.entity_form_display.node.islandora_object.default.yml
+++ b/config/install/core.entity_form_display.node.islandora_object.default.yml
@@ -117,7 +117,6 @@ third_party_settings:
       children:
         - field_full_title
         - field_alt_title
-        - field_alternative_title
       parent_name: ''
       weight: 2
       format_type: details

--- a/modules/islandora_mirador/config/install/core.entity_view_display.node.islandora_object.mirador.yml
+++ b/modules/islandora_mirador/config/install/core.entity_view_display.node.islandora_object.mirador.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.mirador
     - field.field.node.islandora_object.field_access_terms
-    - field.field.node.islandora_object.field_alternative_title
+    - field.field.node.islandora_object.field_alt_title
     - field.field.node.islandora_object.field_classification
     - field.field.node.islandora_object.field_coordinates
     - field.field.node.islandora_object.field_coordinates_text
@@ -52,7 +52,7 @@ targetEntityType: node
 bundle: islandora_object
 mode: mirador
 content:
-  field_alternative_title:
+  field_alt_title:
     type: string
     weight: 0
     region: content


### PR DESCRIPTION
**GitHub Issue**: Islandora/documentation#1980

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

n/a

# What does this Pull Request do?

Removes references to an old field machine name that no longer exists. 

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Changes `field_alternative_title` to `field_alt_title` in `modules/islandora_mirador/config/install/core.entity_view_display.node.islandora_object.mirador.yml`
* Removes `field_alternative_title` from `config/install/core.entity_form_display.node.islandora_object.default.yml`

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

Islandora/documentation#1980 did not describe the problems caused by this. 

You would want to check that mirador works with the changes. 

You would want to verify that the form for islandora_object contains two fields (title and alt_title) in the titles group.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@seth-shaw-unlv 
