### PR TITLE
Fix config conflicts for islandora_mirador

### DIFF
--- a/modules/islandora_mirador/config/install/core.entity_view_display.media.file.mirador.yml
+++ b/modules/islandora_mirador/config/install/core.entity_view_display.media.file.mirador.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.mirador
-    - field.field.media.file.field_access_terms
     - field.field.media.file.field_file_size
     - field.field.media.file.field_media_file
     - field.field.media.file.field_media_of

--- a/modules/islandora_mirador/config/install/core.entity_view_display.media.image.mirador.yml
+++ b/modules/islandora_mirador/config/install/core.entity_view_display.media.image.mirador.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.mirador
-    - field.field.media.image.field_access_terms
     - field.field.media.image.field_file_size
     - field.field.media.image.field_height
     - field.field.media.image.field_media_image

--- a/modules/islandora_mirador/config/install/core.entity_view_display.node.islandora_object.mirador.yml
+++ b/modules/islandora_mirador/config/install/core.entity_view_display.node.islandora_object.mirador.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.mirador
-    - field.field.node.islandora_object.field_access_terms
     - field.field.node.islandora_object.field_alt_title
     - field.field.node.islandora_object.field_classification
     - field.field.node.islandora_object.field_coordinates


### PR DESCRIPTION

# What does this Pull Request do?

remove references to field_access_terms which cause the module to fail to install


# What's new?
Minor config changes that correspond to upstream changes in islandora_defaults


# How should this be tested?
* try to install islandora_mirador. watch it complain about missing access_terms config
* pull in this PR
* try to install islandora_mirador again. watch it succeed (i hope)


# Interested parties
 @Islandora/8-x-committers
