### PR TITLE
Remove access_terms

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: islandora/islandora_ci
-          ref: rosiel-patch-1
+          ref: rosiel-patch-2
           path: islandora_ci
 
       - name: Setup PHP

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Mysql client
         run: |
           sudo apt-get update
-          sudo apt-get install -y mysql-client
+          # sudo apt-get install -y mysql-client # supposed to be pre-installed now
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: islandora/islandora_ci
-          ref: actions_path
+          ref: actions_patch
           path: islandora_ci
 
       - name: Setup PHP

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: islandora/islandora_ci
-          ref: rosiel-patch-1
+          ref: github-actions
           path: islandora_ci
 
       - name: Setup PHP

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: islandora/islandora_ci
-          ref: actions_patch
+          ref: actions-patch
           path: islandora_ci
 
       - name: Setup PHP

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: islandora/islandora_ci
-          ref: github-actions
+          ref: actions_path
           path: islandora_ci
 
       - name: Setup PHP

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: islandora/islandora_ci
-          ref: actions-patch
+          ref: rosiel-patch-1
           path: islandora_ci
 
       - name: Setup PHP

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -62,8 +62,8 @@ jobs:
 
       - name: Setup Mysql client
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mysql-client
+          sudo apt update
+          sudo apt install -y mysql-client
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: islandora/islandora_ci
-          ref: rosiel-patch-2
+          ref: rosiel-patch-1
           path: islandora_ci
 
       - name: Setup PHP

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -62,8 +62,8 @@ jobs:
 
       - name: Setup Mysql client
         run: |
-          sudo apt update
-          sudo apt install -y mysql-client
+          sudo apt-get update
+          sudo apt-get install -y mysql-client
 
       - name: Set environment variables
         run: |

--- a/modules/islandora_mirador/config/install/core.entity_view_display.media.file.mirador.yml
+++ b/modules/islandora_mirador/config/install/core.entity_view_display.media.file.mirador.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.mirador
-    - field.field.media.file.field_access_terms
     - field.field.media.file.field_file_size
     - field.field.media.file.field_media_file
     - field.field.media.file.field_media_of
@@ -27,7 +26,6 @@ content:
     region: content
 hidden:
   created: true
-  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_media_of: true

--- a/modules/islandora_mirador/config/install/core.entity_view_display.media.image.mirador.yml
+++ b/modules/islandora_mirador/config/install/core.entity_view_display.media.image.mirador.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.mirador
-    - field.field.media.image.field_access_terms
     - field.field.media.image.field_file_size
     - field.field.media.image.field_height
     - field.field.media.image.field_media_image
@@ -29,7 +28,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_height: true

--- a/modules/islandora_mirador/config/install/core.entity_view_display.node.islandora_object.mirador.yml
+++ b/modules/islandora_mirador/config/install/core.entity_view_display.node.islandora_object.mirador.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.mirador
-    - field.field.node.islandora_object.field_access_terms
     - field.field.node.islandora_object.field_alt_title
     - field.field.node.islandora_object.field_classification
     - field.field.node.islandora_object.field_coordinates
@@ -322,7 +321,6 @@ hidden:
   display_media_entity_view_2: true
   display_media_service_file: true
   display_media_thumbnail: true
-  field_access_terms: true
   field_display_hints: true
   field_model: true
   field_pid: true


### PR DESCRIPTION
**Slack discussion**: https://islandora.slack.com/archives/C019U12D44Q/p1643905893529709


# What does this Pull Request do?

Solves the unmet dependencies preventing mirador from being installed.

# What's new?

* removed references to a field (that was "hidden" anyway)

# How should this be tested?

Currently when trying to install islandora defaults, it doesn't let you install Islandora_mirador. 
however with this, it can be installed

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@ajstanley
