### PR TITLE
Adds two new views to render OAI-PMH results in collection based sets.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -60,10 +60,9 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: composer:v2
 
-      - name: Setup Mysql client
+      - name: Update Packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y mysql-client
 
       - name: Set environment variables
         run: |

--- a/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
+++ b/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
@@ -1,7 +1,8 @@
 rest_oai_pmh:
   entity_type: node
 view_displays:
-  'oai_pmh:all_repository_items': 'oai_pmh:all_repository_items'
+  'oai_pmh:collection_sets': 'oai_pmh:collection_sets'
+  'oai_pmh:collectionless_set': 'oai_pmh:collectionless_set'
 support_sets: 1
 mapping_source: rdf
 repository_name: 'Islandora 8'
@@ -10,3 +11,4 @@ expiration: '3600'
 metadata_map_plugins:
   oai_raw: ''
   oai_dc: dublin_core_rdf
+cache_technique: liberal_cache

--- a/modules/islandora_oaipmh/config/install/views.view.oai_pmh.yml
+++ b/modules/islandora_oaipmh/config/install/views.view.oai_pmh.yml
@@ -14,12 +14,11 @@ description: ''
 tag: ''
 base_table: node_field_data
 base_field: nid
-core: 8.x
 display:
   default:
     display_plugin: default
     id: default
-    display_title: Main
+    display_title: Master
     position: 0
     display_options:
       access:
@@ -138,6 +137,8 @@ display:
           id: status
           expose:
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
           group: 1
         type:
           id: type
@@ -149,6 +150,9 @@ display:
           entity_field: type
           plugin_id: bundle
           group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
         field_external_uri_uri:
           id: field_external_uri_uri
           table: taxonomy_term__field_external_uri
@@ -173,6 +177,8 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -243,6 +249,204 @@ display:
           search_fields:
             title: title
       display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  collection_sets:
+    display_plugin: entity_reference
+    id: collection_sets
+    display_title: 'Collection Sets'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            title: title
+      display_description: 'All items with collections grouped into a sets per collection they belong to.'
+      arguments:
+        field_member_of_target_id:
+          id: field_member_of_target_id
+          table: node__field_member_of
+          field: field_member_of_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          plugin_id: numeric
+      defaults:
+        arguments: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  collectionless_set:
+    display_plugin: entity_reference
+    id: collectionless_set
+    display_title: 'Collectionless Set'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            title: title
+      display_description: 'Set of items that do not belong to any Collection, to be used with Collection Sets.'
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            islandora_object: islandora_object
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        field_external_uri_uri:
+          id: field_external_uri_uri
+          table: taxonomy_term__field_external_uri
+          field: field_external_uri_uri
+          relationship: field_model
+          group_type: group
+          admin_label: ''
+          operator: '!='
+          value: 'http://purl.org/dc/dcmitype/Collection'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_member_of_target_id:
+          id: field_member_of_target_id
+          table: node__field_member_of
+          field: field_member_of_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: empty
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: numeric
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/islandora_oaipmh/islandora_oaipmh.info.yml
+++ b/modules/islandora_oaipmh/islandora_oaipmh.info.yml
@@ -1,13 +1,12 @@
 name: 'Islandora OAI-PMH Endpoint'
 type: module
 description: 'Default configuration for an OAI-PMH Endpoint'
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: '^8.9 || ^9'
 package: Islandora
 dependencies:
-  - islandora_defaults
-  - node
-  - rest_oai_pmh
-  - taxonomy
-  - user
-  - views
+  - 'drupal:node'
+  - 'drupal:taxonomy'
+  - 'drupal:user'
+  - 'drupal:views'
+  - 'islandora_defaults:islandora_defaults'
+  - 'rest_oai_pmh:rest_oai_pmh'


### PR DESCRIPTION
Uses the new views as the default going forward for OAI-PMH such that `setspec` defaults to the collections in which the item belongs.

Work sponsored by DGI.

**GitHub Issue**: https://github.com/Islandora/documentation/issues/502

# What does this Pull Request do?

Creates two new views for OAI-PMH one returns results as sets of collections and the other handles items which do not belong to any collections.

# How should this be tested?

After installing create some collections and items.

Note that the way OAI-PMH module uses a cron task to update the cached results. You can visit https://islandora.traefik.me/admin/config/services/rest/oai-pmh/queue to manually rebuild the queue.

Test the rest API endpoint while logged in (for example):

List Sets:
https://islandora.traefik.me/oai/request?verb=ListSets&metadataPrefix=oai_dc

List Records:
https://islandora.traefik.me/oai/request?verb=ListRecords&metadataPrefix=oai_dc

List Records in specific set:
https://islandora.traefik.me/oai/request?verb=ListRecords&metadataPrefix=oai_dc&set=node:4

In all cases `setSpec` should be set included in each entry and should be the node id for the collection that record belongs to or `oai_pmh:collectionless_set` for those items which belong to no collections.

# Interested parties
@Islandora/8-x-committers
