### PR TITLE
Add OriginalFile display to IIF Manifest view

### DIFF
--- a/config/install/views.view.iiif_manifest.yml
+++ b/config/install/views.view.iiif_manifest.yml
@@ -368,6 +368,63 @@ display:
         type: none
         options:
           offset: 0
+      filters:
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        field_external_uri_uri:
+          id: field_external_uri_uri
+          table: taxonomy_term__field_external_uri
+          field: field_external_uri_uri
+          relationship: field_media_use
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: '='
+          value: 'http://pcdm.org/use#ServiceFile'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: iiif_manifest
         options:
@@ -381,6 +438,9 @@ display:
             name:
               alias: ''
               raw_output: false
+      defaults:
+        filters: false
+        filter_groups: false
       display_extenders:
         matomo:
           enabled: false

--- a/config/install/views.view.iiif_manifest.yml
+++ b/config/install/views.view.iiif_manifest.yml
@@ -13,9 +13,7 @@ dependencies:
     - rest
     - serialization
     - taxonomy
-    - user
-_core:
-  default_config_hash: LdlFuH72RwGAI7DWqKggg0dlRE4LEvCAojgFdg7u4qQ
+    - user 
 id: iiif_manifest
 label: 'IIIF Manifest'
 module: views
@@ -622,6 +620,10 @@ display:
     display_plugin: rest_export
     position: 3
     display_options:
+      pager:
+        type: none
+        options:
+          offset: 0
       style:
         type: iiif_manifest
         options:
@@ -663,3 +665,4 @@ display:
       tags:
         - 'config:field.storage.media.field_media_file'
         - 'config:field.storage.media.field_media_image'
+

--- a/config/install/views.view.iiif_manifest.yml
+++ b/config/install/views.view.iiif_manifest.yml
@@ -14,6 +14,8 @@ dependencies:
     - serialization
     - taxonomy
     - user
+_core:
+  default_config_hash: LdlFuH72RwGAI7DWqKggg0dlRE4LEvCAojgFdg7u4qQ
 id: iiif_manifest
 label: 'IIIF Manifest'
 module: views
@@ -23,63 +25,12 @@ base_table: media_field_data
 base_field: mid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Main
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'view media'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: serializer
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
+      title: ''
       fields:
         field_media_file:
           id: field_media_file
@@ -88,6 +39,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -143,7 +95,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_media_image:
           id: field_media_image
           table: media__field_media_image
@@ -151,6 +102,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -195,8 +147,10 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: ''
             image_link: ''
+            image_style: ''
+            image_loading:
+              attribute: lazy
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -207,21 +161,109 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'view media'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        field_weight_value:
+          id: field_weight_value
+          table: node__field_weight
+          field: field_weight_value
+          relationship: field_media_of
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_weight_value
+          exposed: false
+      arguments:
+        field_member_of_target_id:
+          id: field_member_of_target_id
+          table: node__field_member_of
+          field: field_member_of_target_id
+          relationship: field_media_of
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:node'
+            fail: 'not found'
+          validate_options:
+            bundles: {  }
+            access: true
+            operation: view
+            multiple: 0
+          break_phrase: false
+          not: false
       filters:
         status:
-          value: '1'
+          id: status
           table: media_field_data
           field: status
-          plugin_id: boolean
           entity_type: media
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_external_uri_uri:
           id: field_external_uri_uri
           table: taxonomy_term__field_external_uri
@@ -229,8 +271,9 @@ display:
           relationship: field_media_use
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: '='
-          value: 'http://pcdm.org/use#ServiceFile'
+          value: 'http://pcdm.org/use#OriginalFile'
           group: 1
           exposed: false
           expose:
@@ -260,23 +303,27 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
-      sorts:
-        field_weight_value:
-          id: field_weight_value
-          table: node__field_weight
-          field: field_weight_value
-          relationship: field_media_of
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
-      header: {  }
-      footer: {  }
-      empty: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: serializer
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         field_media_of:
           id: field_media_of
@@ -285,8 +332,8 @@ display:
           relationship: none
           group_type: group
           admin_label: 'field_media_of: Content'
-          required: true
           plugin_id: standard
+          required: true
         field_media_use:
           id: field_media_use
           table: media__field_media_use
@@ -294,52 +341,11 @@ display:
           relationship: none
           group_type: group
           admin_label: 'field_media_use: Taxonomy term'
-          required: false
           plugin_id: standard
-      arguments:
-        field_member_of_target_id:
-          id: field_member_of_target_id
-          table: node__field_member_of
-          field: field_member_of_target_id
-          relationship: field_media_of
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: node
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:node'
-            fail: 'not found'
-          validate_options:
-            access: true
-            operation: view
-            multiple: 0
-            bundles: {  }
-          break_phrase: false
-          not: false
-          plugin_id: numeric
+          required: false
+      header: {  }
+      footer: {  }
       display_extenders: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
     cache_metadata:
       max-age: -1
       contexts:
@@ -353,13 +359,11 @@ display:
         - 'config:field.storage.media.field_media_file'
         - 'config:field.storage.media.field_media_image'
   rest_export_1:
-    display_plugin: rest_export
     id: rest_export_1
     display_title: 'REST export'
+    display_plugin: rest_export
     position: 1
     display_options:
-      display_extenders: {  }
-      path: node/%node/book-manifest
       pager:
         type: none
         options:
@@ -377,6 +381,19 @@ display:
             name:
               alias: ''
               raw_output: false
+      display_extenders:
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
+      path: node/%node/book-manifest
     cache_metadata:
       max-age: -1
       contexts:
@@ -388,31 +405,15 @@ display:
         - 'config:field.storage.media.field_media_file'
         - 'config:field.storage.media.field_media_image'
   rest_export_2:
-    display_plugin: rest_export
     id: rest_export_2
     display_title: 'REST export - single node'
+    display_plugin: rest_export
     position: 1
     display_options:
-      display_extenders: {  }
-      path: node/%node/manifest
       pager:
         type: none
         options:
           offset: 0
-      style:
-        type: iiif_manifest
-        options:
-          iiif_tile_field:
-            field_media_file: field_media_file
-            field_media_image: field_media_image
-      row:
-        type: data_field
-        options:
-          field_options:
-            name:
-              alias: ''
-              raw_output: false
-      display_description: ''
       arguments:
         field_media_of_target_id:
           id: field_media_of_target_id
@@ -421,6 +422,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           default_action: default
           exception:
             value: all
@@ -434,8 +436,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -447,45 +449,20 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          plugin_id: numeric
-      defaults:
-        arguments: false
-        relationships: false
-        filters: false
-        filter_groups: false
-      relationships:
-        field_media_of:
-          id: field_media_of
-          table: media__field_media_of
-          field: field_media_of
-          relationship: none
-          group_type: group
-          admin_label: 'field_media_of: Content'
-          required: true
-          plugin_id: standard
-        field_media_use:
-          id: field_media_use
-          table: media__field_media_use
-          field: field_media_use
-          relationship: none
-          group_type: group
-          admin_label: 'field_media_use: Taxonomy term'
-          required: false
-          plugin_id: standard
       filters:
         status:
-          value: '1'
+          id: status
           table: media_field_data
           field: status
-          plugin_id: boolean
           entity_type: media
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_external_uri_uri:
           id: field_external_uri_uri
           table: taxonomy_term__field_external_uri
@@ -493,6 +470,7 @@ display:
           relationship: field_media_use
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: '='
           value: 'http://pcdm.org/use#ServiceFile'
           group: 1
@@ -524,11 +502,97 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: iiif_manifest
+        options:
+          iiif_tile_field:
+            field_media_file: field_media_file
+            field_media_image: field_media_image
+      row:
+        type: data_field
+        options:
+          field_options:
+            name:
+              alias: ''
+              raw_output: false
+      defaults:
+        relationships: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      relationships:
+        field_media_of:
+          id: field_media_of
+          table: media__field_media_of
+          field: field_media_of
+          relationship: none
+          group_type: group
+          admin_label: 'field_media_of: Content'
+          plugin_id: standard
+          required: true
+        field_media_use:
+          id: field_media_use
+          table: media__field_media_use
+          field: field_media_use
+          relationship: none
+          group_type: group
+          admin_label: 'field_media_use: Taxonomy term'
+          plugin_id: standard
+          required: false
+      display_description: ''
+      display_extenders: {  }
+      path: node/%node/manifest
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - user.permissions
+      tags:
+        - 'config:field.storage.media.field_media_file'
+        - 'config:field.storage.media.field_media_image'
+  rest_export_3:
+    id: rest_export_3
+    display_title: 'Book Manifest (Original File)'
+    display_plugin: rest_export
+    position: 3
+    display_options:
+      style:
+        type: iiif_manifest
+        options:
+          uses_fields: false
+          iiif_tile_field:
+            field_media_file: field_media_file
+            field_media_image: field_media_image
+      row:
+        type: data_field
+        options:
+          field_options:
+            field_media_file:
+              alias: ''
+              raw_output: false
+            field_media_image:
+              alias: ''
+              raw_output: false
+      display_description: ''
+      display_extenders:
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
+      path: node/%node/book-manifest-original
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
# What does this Pull Request do?

Add a display to the IIIF Manifest view that contains media tagged as OriginalFIle.

# What's new?

Just a new display mode for IIF manifest. 


# How should this be tested?

1. Check out this branch of islandora_defaults:

If islandora_defaults does not have a .git subfolder, do the following:

```bash
cd /var/www/html/drupal # or the equivalent if ISLE is different
composer remove islandora/islandora_defaults 
# You may need to agree to some prompts from composer at this point 
composer require --prefer-install=source islandora/islandora_defaults 
cd web/modules/contrib/islandora_defaults
git checkout iiif_original
```
2.  re-import islandora_defaults feature
```bash
$ drush fim -y islandora_defaults
```
2. Enable islandora_mirador module
```bash
drush en islandora_mirador
```
2. Create paged content: 
     Repository item with model "Paged Content
    1 or more Repository items with model Page, and MemberOf relationship to the Paged Content item
    Media of type "File" for each of the Page items, containing a TIFF file.
4. GO to the URL /node/[nid]/book-manifest where nid is the Paged Content item.Go to  to verify existing behaviour, you should see some JSON describing the book structure.
3. GO to the URL /node/[nid]/book-manifest-original where nid is the Paged Content item.
5. Verify that the manifest contains references to the children's OriginalFile media.

# Additional Notes:

Some types of files such as maps aren't served well by the JPG ServiceFile which is of limited resolution.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
