### PR TITLE
Fix broken composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "drupal/field_group" : "^3.0",
     "drupal/field_permissions" : "^1.0",
     "drupal/pdf": "^1.1"
-  }
+  },
   "conflict": {
     "drupal/core": "<=8"
   }


### PR DESCRIPTION
**GitHub Issue**: (link)

https://github.com/Islandora/islandora/pull/886

# What does this Pull Request do?

Corrects my typo in the composer.json

# What's new?

Yesterday I accidentally pushed a change directly to the islandora repo. I deprecated Drupal 8 and made sure there was a `conflict` directive in the composer.json. But I forgot to add a comma. So currently (on islandora_defaults 2.x-dev) the composer file is broken.

# How should this be tested?

If CI builds, which it [does on my github repo](https://github.com/rosiel/islandora_defaults/actions/runs/2708780845), then it works.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@Islandora/committers 
