### PR TITLE
Use Content type as a condition instead of Node bundle.

### DIFF
--- a/config/install/context.context.repository_content.yml
+++ b/config/install/context.context.repository_content.yml
@@ -1,26 +1,27 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - islandora
     - node
-name: repository_content
+  enforced:
+    module:
+      - islandora_defaults
 label: Content
+name: repository_content
 group: Indexing
 description: 'All repository content'
 requireAllConditions: false
 disabled: false
 conditions:
-  node_type:
-    id: node_type
-    bundles:
-      islandora_object: islandora_object
-    negate: 0
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: a3cfee79-6ab9-4e83-8c19-995dcbca2a44
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      islandora_object: islandora_object
 reactions:
   index:
     id: index


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2148

* This slack discussion: https://islandora.slack.com/archives/CM5PPAV28/p1659465077337079

# What does this Pull Request do?

* Node bundle is a deprecated as a condition for context. It is being
  replaced in the repository_content context with Content type.
* Resolves https://github.com/Islandora/documentation/issues/2148

# What's new?

Node bundle is a deprecated as a condition for context. It is being
  replaced in the repository_content context with Content type.

# How should this be tested?

* Build 9.4.x site with old version, create a node, and it will not be indexed in fcrepo.
* Build 9.4.x site with new version, create a node, and it will be indexed in fcrepo.

# Interested parties

@ajstanley @Islandora/committers 
