### PR TITLE
Sunsetting: Remove config enforcement, and post-update hook to do so for existing sites

### DIFF
--- a/.github/workflows/build-3.x.yml
+++ b/.github/workflows/build-3.x.yml
@@ -107,7 +107,7 @@ jobs:
           composer config minimum-stability dev
           composer require "islandora/islandora:^2"
           composer require "drupal/search_api_solr:^4.1"
-          composer require "islandora/islandora_defaults:dev-github-testing as dev-2.x" --prefer-source -W
+          composer require "islandora/islandora_defaults:dev-github-testing as 3.x-dev" --prefer-source -W
 
       - name: Install modules
         run: |

--- a/.github/workflows/build-3.x.yml
+++ b/.github/workflows/build-3.x.yml
@@ -25,12 +25,12 @@ jobs:
         php-versions: ["7.4", "8.0"]
         drupal-version: ["9.3.x", "9.4.x", "9.5.x-dev"]
         mysql: ["8.0"]
+        allowed_failure: ["false"]
         include:
-          - allowed_failure: false
           - php-versions: "8.1"
-            allowed_failure: true
+            allowed_failure: "true"
 
-    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }}    
+    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }}
     services:
       mysql:
         image: mysql:${{ matrix.mysql }}
@@ -66,7 +66,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer:v2
-      
+
       - name: Setup Mysql client
         run: |
           sudo apt-get update

--- a/.github/workflows/build-3.x.yml
+++ b/.github/workflows/build-3.x.yml
@@ -22,11 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["7.4", "8.0"]
+        php-versions: ["7.4", "8.0", "8.1"]
         drupal-version: ["9.3.x", "9.4.x", "9.5.x-dev"]
         mysql: ["8.0"]
-        allowed_failure: ["false"]
         include:
+          - allowed_failure: "false"
           - php-versions: "8.1"
             allowed_failure: "true"
 

--- a/.github/workflows/build-3.x.yml
+++ b/.github/workflows/build-3.x.yml
@@ -1,0 +1,121 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the target branch
+  push:
+    branches: [ 3.x ]
+  pull_request:
+    branches: [ 3.x ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ["7.4", "8.0"]
+        drupal-version: ["9.3.x", "9.4.x", "9.5.x-dev"]
+        mysql: ["8.0"]
+        include:
+          - allowed_failure: false
+          - php-versions: "8.1"
+            allowed_failure: true
+
+    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }}    
+    services:
+      mysql:
+        image: mysql:${{ matrix.mysql }}
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: drupal
+        ports:
+          - 3306:3306
+      activemq:
+        image: webcenter/activemq:5.14.3
+        ports:
+          - 8161:8161
+          - 61616:61616
+          - 61613:61613
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: build_dir
+
+      - name: Checkout islandora_ci
+        uses: actions/checkout@v2
+        with:
+          repository: islandora/islandora_ci
+          ref: github-actions
+          path: islandora_ci
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: composer:v2
+      
+      - name: Setup Mysql client
+        run: |
+          sudo apt-get update
+          sudo apt-get remove -y mysql-client mysql-common
+          sudo apt-get install -y mysql-client
+
+      - name: Update Packages
+        run: |
+          sudo apt-get update
+
+      - name: Set environment variables
+        run: |
+          echo "DRUPAL_VERSION=${{ matrix.drupal-version }}" >> $GITHUB_ENV
+          echo "SCRIPT_DIR=$GITHUB_WORKSPACE/islandora_ci" >> $GITHUB_ENV
+          echo "DRUPAL_DIR=/opt/drupal" >> $GITHUB_ENV
+          echo "PHPUNIT_FILE=$GITHUB_WORKSPACE/build_dir/phpunit.xml" >> $GITHUB_ENV
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+
+      - name: Setup Drupal
+        run: |
+          mkdir $DRUPAL_DIR
+          $SCRIPT_DIR/travis_setup_drupal.sh
+          cd $DRUPAL_DIR
+          chmod -R u+w web/sites/default
+          mkdir -p web/sites/simpletest/browser_output
+        continue-on-error: ${{ matrix.allowed_failure }}
+
+      - name: Setup composer paths
+        run: |
+          git -C "$GITHUB_WORKSPACE/build_dir" checkout -b github-testing
+          cd $DRUPAL_DIR
+          composer config repositories.local path "$GITHUB_WORKSPACE/build_dir"
+          composer config minimum-stability dev
+          composer require "islandora/islandora:^2"
+          composer require "drupal/search_api_solr:^4.1"
+          composer require "islandora/islandora_defaults:dev-github-testing as dev-2.x" --prefer-source -W
+
+      - name: Install modules
+        run: |
+          cd $DRUPAL_DIR/web
+          drush --uri=127.0.0.1:8282 en -y islandora_audio islandora_breadcrumbs islandora_iiif islandora_image islandora_video islandora_text_extraction_defaults islandora_search
+          drush --uri=127.0.0.1:8282 fim -y islandora_core_feature,islandora_text_extraction_defaults,islandora_defaults,islandora_search
+
+
+      - name: Test scripts
+        run: $SCRIPT_DIR/travis_scripts.sh
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,193 @@
 
 ## Future Development
 
-Islandora Defaults is no longer under active development. Its core purpose is being superceded by a project to create an example Starter Site. You can read the announcement [here](https://groups.google.com/u/1/g/islandora/c/uGzhTnW4TUI).
+Islandora Defaults is no longer under active development, and is being deprecated. Its core purpose is being (and has been) superseded by a project to create an example Starter Site, which [exists in the `islandora-starter-site` repository](https://github.com/Islandora/islandora-starter-site). You can read the announcement [here](https://groups.google.com/u/1/g/islandora/c/uGzhTnW4TUI).
+
+### Deprecation/Removal Preparation
+
+To ease the removal of this module from existing installations, we have implemented a post-update hook which should remove any references to this module from configuration entities that it installed. To make use of it, it should be sufficient to update to the `islandora/islandora_defaults` package in your Drupal project such that it includes the new hook, and to run it. On the CLI, this might be effected as something like:
+
+```bash
+# Navigate to the root of your Composer project; for example:
+cd /var/www/html/drupal
+
+# Update islandora/islandora_defaults such that it has the post-update hooks
+# available. Presently anticipating a "3.0.1" release to which it should update.
+composer require "islandora/islandora_defaults:^3"
+
+# Clear cache (paranoia; to ensure the update hooks are appropriately
+# discovered).
+drush cr
+
+# Run the update hook.
+drush updb
+
+# Now that our config entities should stay behind, the module itself should be
+# fine to be uninstalled. Note that this should/may also result in the
+# uninstallation of the islandora_oaipmh and islandora_search modules; though,
+# the configurations they included should remain in the system.
+drush pm-uninstall islandora_defaults
+
+# Perform a dry-run removal to list out all that would be removed, when
+# islandora/islandora_defaults is removed, as some modules may only be included
+# transitively.
+composer remove --dry-run islandora/islandora_defaults
+
+# Add back some of the modules that might just be included in the project
+# transitively, for example:
+composer require "drupal/field_group:^3" "drupal/field_permissions:^1" \
+  "islandora/controlled_access_terms:^2" "islandora/islandora_mirador:^2"
+# However, in the event that you indeed are not using some of these modules, you
+# might instead proceed to ensure that they are uninstalled from Drupal, similar
+# to the "drush pm-uninstall" invocation above. For the version specs to use, it
+# may be useful to refer to what the our `composer.json` specifies.
+
+# Remove the package from the project entirely.
+composer remove islandora/islandora_defaults
+
+# Clear the caches, for cleanup/paranoia.
+drush cr
+
+# Restart your webserver to register the movement of islandora_mirador from
+# submodule to a module in its own right; otherwise, caching of class
+# definitions might lead to errors. The command might look something like:
+sudo systemctl restart apache2
+```
+
+<details>
+<summary>With output in context, what this might look like</summary>
+
+This was executed on a revived `standard` instance of `islandora-playbook`, with
+some very minor preparation to work around the fact that the update hook code
+did not yet exist in released code (and so had to point at the development
+branch (`dev-fix/config-enforcement`) and made use of aliases accordingly (
+`[...] as 3.x-dev`)). When running post-release, the version spec `^3` should be
+able to be used instead.
+
+```
+vagrant@islandora8:~$ cd /var/www/html/drupal
+vagrant@islandora8:/var/www/html/drupal$ composer require "islandora/islandora_defaults:dev-fix/config-enforcement as 3.x-dev"
+./composer.json has been updated
+Running composer update islandora/islandora_defaults
+Loading composer repositories with package information
+Info from https://repo.packagist.org: #StandWithUkraine
+Updating dependencies
+Lock file operations: 1 install, 1 update, 0 removals
+  - Upgrading islandora/islandora_defaults (2.1.1 => dev-fix/config-enforcement dac37d2)
+  - Locking islandora/islandora_mirador (2.2.1)
+Writing lock file
+Installing dependencies from lock file (including require-dev)
+Package operations: 1 install, 1 update, 0 removals
+  - Downloading islandora/islandora_mirador (2.2.1)
+  - Downloading islandora/islandora_defaults (dev-fix/config-enforcement dac37d2)
+  - Installing islandora/islandora_mirador (2.2.1): Extracting archive
+  - Upgrading islandora/islandora_defaults (2.1.1 => dev-fix/config-enforcement dac37d2): Extracting archive
+Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
+Package silex/silex is abandoned, you should avoid using it. Use symfony/flex instead.
+Package symfony/debug is abandoned, you should avoid using it. Use symfony/error-handler instead.
+Package webmozart/path-util is abandoned, you should avoid using it. Use symfony/filesystem instead.
+Generating autoload files
+68 packages you are using are looking for funding.
+Use the `composer fund` command to find out more!
+No security vulnerability advisories found
+vagrant@islandora8:/var/www/html/drupal$ drush cr
+ [warning] Illegal string offset 'label' OaiPmh.php:116
+ [warning] Illegal string offset 'value' OaiPmh.php:116
+ [warning] Illegal string offset 'label' OaiPmh.php:116
+ [warning] Illegal string offset 'value' OaiPmh.php:116
+ [success] Cache rebuild complete.
+vagrant@islandora8:/var/www/html/drupal$ drush updb
+ -------------------- ------------- ------------- ---------------------------
+  Module               Update ID     Type          Description
+ -------------------- ------------- ------------- ---------------------------
+  islandora_defaults   remove_enfo   post-update   Remove "enforced"
+                       rced_depend                 dependency on this module
+                       ency                        from installed config.
+ -------------------- ------------- ------------- ---------------------------
+
+
+ Do you wish to run the specified pending updates? (yes/no) [yes]:
+ >
+
+>  [notice] Update started: islandora_defaults_post_update_remove_enforced_dependency
+>  [notice] Update completed: islandora_defaults_post_update_remove_enforced_dependency
+>  [warning] Illegal string offset 'label' OaiPmh.php:116
+>  [warning] Illegal string offset 'value' OaiPmh.php:116
+>  [warning] Illegal string offset 'label' OaiPmh.php:116
+>  [warning] Illegal string offset 'value' OaiPmh.php:116
+ [success] Finished performing updates.
+vagrant@islandora8:/var/www/html/drupal$ drush pm-uninstall islandora_defaults
+The following extensions will be uninstalled: islandora_defaults, islandora_oaipmh, islandora_search
+
+ Do you want to continue? (yes/no) [yes]:
+ >
+
+ [warning] Illegal string offset 'label' OaiPmh.php:116
+ [warning] Illegal string offset 'value' OaiPmh.php:116
+ [warning] Illegal string offset 'label' OaiPmh.php:116
+ [warning] Illegal string offset 'value' OaiPmh.php:116
+ [success] Successfully uninstalled: islandora_defaults, islandora_oaipmh, islandora_search
+vagrant@islandora8:/var/www/html/drupal$ composer require "drupal/field_group:^3" "drupal/field_permissions:^1"   "islandora/controlled_access_terms:^2" "islandora/islandora_mirador:^2"
+./composer.json has been updated
+Running composer update drupal/field_group drupal/field_permissions islandora/controlled_access_terms islandora/islandora_mirador
+Loading composer repositories with package information
+Updating dependencies
+Nothing to modify in lock file
+Installing dependencies from lock file (including require-dev)
+Package operations: 0 installs, 0 updates, 0 removals
+Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
+Package silex/silex is abandoned, you should avoid using it. Use symfony/flex instead.
+Package symfony/debug is abandoned, you should avoid using it. Use symfony/error-handler instead.
+Package webmozart/path-util is abandoned, you should avoid using it. Use symfony/filesystem instead.
+Generating autoload files
+68 packages you are using are looking for funding.
+Use the `composer fund` command to find out more!
+No security vulnerability advisories found
+vagrant@islandora8:/var/www/html/drupal$ composer remove islandora/islandora_defaults
+./composer.json has been updated
+Running composer update islandora/islandora_defaults
+Loading composer repositories with package information
+Updating dependencies
+Lock file operations: 0 installs, 0 updates, 1 removal
+  - Removing islandora/islandora_defaults (dev-fix/config-enforcement dac37d2)
+Writing lock file
+Installing dependencies from lock file (including require-dev)
+Package operations: 0 installs, 0 updates, 1 removal
+  - Removing islandora/islandora_defaults (dev-fix/config-enforcement dac37d2)
+Deleting web/modules/contrib/islandora_defaults - deleted
+Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
+Package silex/silex is abandoned, you should avoid using it. Use symfony/flex instead.
+Package symfony/debug is abandoned, you should avoid using it. Use symfony/error-handler instead.
+Package webmozart/path-util is abandoned, you should avoid using it. Use symfony/filesystem instead.
+Generating autoload files
+68 packages you are using are looking for funding.
+Use the `composer fund` command to find out more!
+No security vulnerability advisories found
+vagrant@islandora8:/var/www/html/drupal$ drush cr
+ [warning] Illegal string offset 'label' OaiPmh.php:116
+ [warning] Illegal string offset 'value' OaiPmh.php:116
+ [warning] Illegal string offset 'label' OaiPmh.php:116
+ [warning] Illegal string offset 'value' OaiPmh.php:116
+ [success] Cache rebuild complete.
+vagrant@islandora8:/var/www/html/drupal$ sudo systemctl restart apache2
+vagrant@islandora8:/var/www/html/drupal$
+```
+
+The warnings:
+
+```
+ [warning] Illegal string offset 'label' OaiPmh.php:116
+ [warning] Illegal string offset 'value' OaiPmh.php:116
+```
+
+... are from `islandora_defaults` shipping configuration for an older schema
+([commit which changed it](https://git.drupalcode.org/project/rest_oai_pmh/-/commit/784d827eb77cd2513b66054b31b7dfae54f469c2))
+of the [REST OAI-PMH module](https://www.drupal.org/project/rest_oai_pmh), of
+which it is outside the scope of present efforts to address.
+
+</details>
+
+---
 
 ## Introduction
 
@@ -30,7 +216,7 @@ Further [documentation for this module](https://islandora.github.io/documentatio
 
 ## Troubleshooting/Issues
 
-Having problems or solved a problem? Check out the Islandora google groups for a solution.
+Having problems or solved a problem? Check out the Islandora Google Groups for a solution.
 
 * [Islandora Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ cd /var/www/html/drupal
 # Update islandora/islandora_defaults such that it has the post-update hooks
 # available. Presently anticipating a "3.0.1" release to which it should update.
 composer require "islandora/islandora_defaults:^3"
+# A caveat exists in that, if `islandora/islandora_defaults` is required by any
+# other Composer package, then those packages may have to be updated first; for
+# example, it is known that there exist Drupal installation profiles that
+# specify a dependency on `islandora/islandora_defaults` (such as https://github.com/Islandora-Devops/islandora_install_profile_demo/blob/181a53bb230d7ced6e70e7746f0da567216ebbf7/composer.json#L157),
+# which would likely have to receive a treatment to strip out any references
+# from their configurations which explicitly bind to `islandora_defaults`
+# similar to our update hook, and to include updated requirements accordingly
+# in the root Composer project.
 
 # Clear cache (paranoia; to ensure the update hooks are appropriately
 # discovered).

--- a/config/install/context.context.binary.yml
+++ b/config/install/context.context.binary.yml
@@ -1,9 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - islandora
 name: binary

--- a/config/install/context.context.collection.yml
+++ b/config/install/context.context.collection.yml
@@ -1,9 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - islandora
 name: collection

--- a/config/install/context.context.repository_content.yml
+++ b/config/install/context.context.repository_content.yml
@@ -4,9 +4,6 @@ dependencies:
   module:
     - islandora
     - node
-  enforced:
-    module:
-      - islandora_defaults
 label: Content
 name: repository_content
 group: Indexing

--- a/config/install/context.context.taxonomy_terms.yml
+++ b/config/install/context.context.taxonomy_terms.yml
@@ -1,9 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - islandora
 name: taxonomy_terms

--- a/config/install/core.entity_form_display.node.islandora_object.default.yml
+++ b/config/install/core.entity_form_display.node.islandora_object.default.yml
@@ -47,9 +47,6 @@ dependencies:
     - field.field.node.islandora_object.field_temporal_subject
     - field.field.node.islandora_object.field_weight
     - node.type.islandora_object
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - controlled_access_terms
     - field_group

--- a/config/install/core.entity_view_display.media.file.open_seadragon.yml
+++ b/config/install/core.entity_view_display.media.file.open_seadragon.yml
@@ -10,9 +10,6 @@ dependencies:
     - field.field.media.file.field_mime_type
     - field.field.media.file.field_original_name
     - media.type.file
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - openseadragon
 id: media.file.open_seadragon

--- a/config/install/core.entity_view_display.media.image.open_seadragon.yml
+++ b/config/install/core.entity_view_display.media.image.open_seadragon.yml
@@ -12,9 +12,6 @@ dependencies:
     - field.field.media.image.field_original_name
     - field.field.media.image.field_width
     - media.type.image
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - openseadragon
 id: media.image.open_seadragon

--- a/config/install/core.entity_view_display.node.islandora_object.binary.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.binary.yml
@@ -48,9 +48,6 @@ dependencies:
     - field.field.node.islandora_object.field_temporal_subject
     - field.field.node.islandora_object.field_weight
     - node.type.islandora_object
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - controlled_access_terms
     - geolocation

--- a/config/install/core.entity_view_display.node.islandora_object.default.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.default.yml
@@ -47,9 +47,6 @@ dependencies:
     - field.field.node.islandora_object.field_temporal_subject
     - field.field.node.islandora_object.field_weight
     - node.type.islandora_object
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - controlled_access_terms
     - geolocation

--- a/config/install/core.entity_view_display.node.islandora_object.open_seadragon.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.open_seadragon.yml
@@ -48,9 +48,6 @@ dependencies:
     - field.field.node.islandora_object.field_temporal_subject
     - field.field.node.islandora_object.field_weight
     - node.type.islandora_object
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - controlled_access_terms
     - geolocation

--- a/config/install/core.entity_view_display.node.islandora_object.pdfjs.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.pdfjs.yml
@@ -48,9 +48,6 @@ dependencies:
     - field.field.node.islandora_object.field_temporal_subject
     - field.field.node.islandora_object.field_weight
     - node.type.islandora_object
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - controlled_access_terms
     - geolocation

--- a/config/install/core.entity_view_display.node.islandora_object.teaser.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.teaser.yml
@@ -48,9 +48,6 @@ dependencies:
     - field.field.node.islandora_object.field_temporal_subject
     - field.field.node.islandora_object.field_weight
     - node.type.islandora_object
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - user
 id: node.islandora_object.teaser

--- a/config/install/core.entity_view_mode.media.open_seadragon.yml
+++ b/config/install/core.entity_view_mode.media.open_seadragon.yml
@@ -1,9 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - media
 id: media.open_seadragon

--- a/config/install/core.entity_view_mode.node.binary.yml
+++ b/config/install/core.entity_view_mode.node.binary.yml
@@ -1,9 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - node
 id: node.binary

--- a/config/install/core.entity_view_mode.node.open_seadragon.yml
+++ b/config/install/core.entity_view_mode.node.open_seadragon.yml
@@ -1,9 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - node
 id: node.open_seadragon

--- a/config/install/field.field.node.islandora_object.field_description.yml
+++ b/config/install/field.field.node.islandora_object.field_description.yml
@@ -4,9 +4,6 @@ dependencies:
   config:
     - field.storage.node.field_description
     - node.type.islandora_object
-  enforced:
-    module:
-      - islandora_defaults
 id: node.islandora_object.field_description
 field_name: field_description
 entity_type: node

--- a/config/install/field.field.node.islandora_object.field_display_hints.yml
+++ b/config/install/field.field.node.islandora_object.field_display_hints.yml
@@ -5,9 +5,6 @@ dependencies:
     - field.storage.node.field_display_hints
     - node.type.islandora_object
     - taxonomy.vocabulary.islandora_display
-  enforced:
-    module:
-      - islandora_defaults
 id: node.islandora_object.field_display_hints
 field_name: field_display_hints
 entity_type: node

--- a/config/install/field.field.node.islandora_object.field_member_of.yml
+++ b/config/install/field.field.node.islandora_object.field_member_of.yml
@@ -4,9 +4,6 @@ dependencies:
   config:
     - field.storage.node.field_member_of
     - node.type.islandora_object
-  enforced:
-    module:
-      - islandora_defaults
 id: node.islandora_object.field_member_of
 field_name: field_member_of
 entity_type: node

--- a/config/install/field.field.node.islandora_object.field_model.yml
+++ b/config/install/field.field.node.islandora_object.field_model.yml
@@ -5,9 +5,6 @@ dependencies:
     - field.storage.node.field_model
     - node.type.islandora_object
     - taxonomy.vocabulary.islandora_models
-  enforced:
-    module:
-      - islandora_defaults
 id: node.islandora_object.field_model
 field_name: field_model
 entity_type: node

--- a/config/install/node.type.islandora_object.yml
+++ b/config/install/node.type.islandora_object.yml
@@ -1,9 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - menu_ui
 third_party_settings:

--- a/config/install/rdf.mapping.node.islandora_object.yml
+++ b/config/install/rdf.mapping.node.islandora_object.yml
@@ -3,9 +3,6 @@ status: true
 dependencies:
   config:
     - node.type.islandora_object
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - node
 id: node.islandora_object

--- a/config/install/views.view.openseadragon_media_evas.yml
+++ b/config/install/views.view.openseadragon_media_evas.yml
@@ -3,9 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.open_seadragon
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - eva
     - media

--- a/config/install/views.view.pdfjs_media_evas.yml
+++ b/config/install/views.view.pdfjs_media_evas.yml
@@ -3,9 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.pdfjs
-  enforced:
-    module:
-      - islandora_defaults
   module:
     - eva
     - media

--- a/islandora_defaults.post_update.php
+++ b/islandora_defaults.post_update.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file
+ * Post-update hooks.
+ */
+
+/**
+ * Remove "enforced" dependency on this module from installed config.
+ */
+function islandora_defaults_post_update_remove_enforced_dependency() {
+  // XXX: Notably absent from this list is the migration defined by the
+  // migrate_plus.migration.islandora_defaults_tags config entity; however,
+  // given this migration depends on content that is explicitly part of this
+  // module (the CSV from which it takes its data), it would leave it in an
+  // inconsistent state if we were to leave the entity intact.
+  $targets = [
+  	'context.context.binary',
+    'context.context.collection',
+    'context.context.repository_content',
+    'context.context.taxonomy_terms',
+    'core.entity_form_display.node.islandora_object.default',
+    'core.entity_view_display.media.file.open_seadragon',
+    'core.entity_view_display.media.image.open_seadragon',
+    'core.entity_view_display.node.islandora_object.binary',
+    'core.entity_view_display.node.islandora_object.default',
+    'core.entity_view_display.node.islandora_object.open_seadragon',
+    'core.entity_view_display.node.islandora_object.pdfjs',
+    'core.entity_view_display.node.islandora_object.teaser',
+    'core.entity_view_mode.media.open_seadragon',
+    'core.entity_view_mode.node.binary',
+    'core.entity_view_mode.node.open_seadragon',
+    'field.field.node.islandora_object.field_description',
+    'field.field.node.islandora_object.field_display_hints',
+    'field.field.node.islandora_object.field_member_of',
+    'field.field.node.islandora_object.field_model',
+    'node.type.islandora_object',
+    'rdf.mapping.node.islandora_object',
+    'views.view.openseadragon_media_evas',
+    'views.view.pdfjs_media_evas',
+  ];
+
+  $diff_set = ['islandora_defaults'];
+
+  /** @var \Drupal\Core\Config\ConfigFactoryInterface $config_factory */
+  $config_factory = \Drupal::service('config.factory');
+  foreach ($targets as $target) {
+    $editable_target = $config_factory->getEditable($target);
+    if ($editable_target->isNew()) {
+      // We do not want to _create_ any of the configs, just change them if they
+      // exist, so if it turns out that we would be creating the config, skip
+      // it.
+      continue;
+    }
+
+    $current_set = $editable_target->get('dependencies.enforced.module');
+    $post_diff = array_diff($current_set, $diff_set);
+    if ($post_diff !== $current_set) {
+      $editable_target->set('dependencies.enforced.module', $post_diff);
+      $editable_target->save();
+    }
+  }
+}

--- a/islandora_defaults.post_update.php
+++ b/islandora_defaults.post_update.php
@@ -15,7 +15,7 @@ function islandora_defaults_post_update_remove_enforced_dependency() {
   // module (the CSV from which it takes its data), it would leave it in an
   // inconsistent state if we were to leave the entity intact.
   $targets = [
-  	'context.context.binary',
+    'context.context.binary',
     'context.context.collection',
     'context.context.repository_content',
     'context.context.taxonomy_terms',


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/islandora_defaults/issues/74 / https://github.com/Islandora/islandora-starter-site/issues/2

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Introduces a (post-)update hook and documents its usage in the process of removing of this module.

# What's new?

The module is removable without removing its config, with a new post-update hook to facilitate existing installations.

* Does this change require documentation to be updated? Probably?
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Somewhat... ish? Has knock-on effects with other packages, but the update hook on its own does not really... it's more the other process of removing the module that gets into things.

# How should this be tested?

Easiest might be to:
1. Spin up a "revived" instance of the `standard` `islandora-playbook`, to get a a base environment with `islandora_defaults` still present
    * Should be sufficient to just grab the [old `standard.yml`](https://github.com/Islandora-Devops/islandora-playbook/blob/632f2aff800a6d844ca85d14abc035cb8529a196/vars/standard.yml) into `islandora-playbook`'s `vars` directory
    * Then, the usual: `ISLANDORA_INSTALL_PROFILE=standard vagrant up`
2. Perform a config export: `drush config:export sync`
3. Run through the "Deprecation/Removal Preparation" steps in the `README.md`
    * Before merge/release, it will be necessary to first add a repository entry to `/var/www/html/drupal/composer.json`, pointing at the repo containing the branch being merged here, and to specify it in lieu of `^3`... so, something like: `composer require "islandora/islandora_defaults:dev-fix/config-enforcement as 3.x-dev"` as the example output of execution presently uses instead of the `composer require "islandora/islandora_defaults:^3"` which is in the main doc.
    * ... should do the trick.
4. Do another config export, but examine the diff: `drush config:export sync --diff`
    * Should just see the `enforced` statements targeting `islandora_defaults` going away, and entries from the `core.extension` changing according to the modules that were uninstalled (and possibly some re-ordering of properties just due to config doing config things). 

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
