### PR TITLE
Update metadata_map_plugins OAI setting

### DIFF
--- a/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
+++ b/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
@@ -9,6 +9,16 @@ repository_name: 'Islandora 8'
 repository_email: admin@example.com
 expiration: '3600'
 metadata_map_plugins:
-  oai_raw: ''
-  oai_dc: dublin_core_rdf
+  -
+    label: oai_dc
+    value: dublin_core_rdf
+  -
+    label: oai_raw
+    value: ''
+  -
+    label: mods
+    value: ''
 cache_technique: liberal_cache
+mods_view:
+  view_machine_name: ''
+  view_display_name: ''


### PR DESCRIPTION
# What does this Pull Request do?

Fixes the OAI-PMH default setting module from failing on new installs

# What's new?

Updated the `rest_oai_pmh` config to its new schema.

# How should this be tested?

A description of what steps someone could take to:

* Reproduce the problem you are fixing (if applicable)

Create a new Drupal site with and enable Islandora OAI PMH. It will error

```
Cannot access offset of type string on string in Drupal\rest_oai_pmh\Plugin\rest\resource\OaiPmh->__construct() (line 116 of /code/web/modules/contrib/rest_oai_pmh/src/Plugin/rest/resource/OaiPmh.php)
```

# Interested parties
@Islandora/committers
